### PR TITLE
Implement cached version of evaluator and labeling methods for HMM

### DIFF
--- a/include/model/HiddenMarkovModel.hpp
+++ b/include/model/HiddenMarkovModel.hpp
@@ -149,13 +149,6 @@ class HiddenMarkovModel
   virtual void posteriorProbabilities(const Sequence &sequence,
                                       Matrix &probabilities) const override;
 
-  // Concrete methods
-  // Estimation<Labeling<Sequence>>
-  // simpleLabeling(SEPtr evaluator, Labeling<Sequence>::Method method);
-  //
-  // Estimation<Labeling<Sequence>>
-  // cachedLabeling(CEPtr evaluator, Labeling<Sequence>::Method method);
-
   unsigned int stateAlphabetSize() const;
   unsigned int observationAlphabetSize() const;
   HiddenMarkovModelStatePtr state(unsigned int i) const;
@@ -176,7 +169,7 @@ class HiddenMarkovModel
   posteriorDecoding(const Sequence &xs, Matrix &probabilities) const override;
 
   // Concrete methods
-  void initializeCache(const Sequence &sequence, Cache &cache);
+  void initializePrefixSumArray(const Sequence &sequence, Cache &cache);
 };
 
 }  // namespace model

--- a/include/model/HiddenMarkovModel.hpp
+++ b/include/model/HiddenMarkovModel.hpp
@@ -81,6 +81,13 @@ class HiddenMarkovModel
   // Overriden methods
   void initializeCache(CEPtr<Standard> evaluator,
                        unsigned int phase) override;
+  Probability evaluateSymbol(CEPtr<Standard> evaluator,
+                             unsigned int pos,
+                             unsigned int phase) const override;
+  Probability evaluateSequence(CEPtr<Standard> evaluator,
+                               unsigned int begin,
+                               unsigned int end,
+                               unsigned int phase) const override;
 
   Probability evaluateSymbol(SEPtr<Standard> evaluator,
                              unsigned int pos,
@@ -90,29 +97,21 @@ class HiddenMarkovModel
                                unsigned int end,
                                unsigned int phase) const override;
 
-  Probability evaluateSymbol(CEPtr<Standard> evaluator,
-                             unsigned int pos,
-                             unsigned int phase) const override;
-  Probability evaluateSequence(CEPtr<Standard> evaluator,
-                               unsigned int begin,
-                               unsigned int end,
-                               unsigned int phase) const override;
 
   void initializeCache(CEPtr<Labeling> evaluator,
                        unsigned int phase) override;
+  Probability evaluateSymbol(CEPtr<Labeling> evaluator,
+                             unsigned int pos,
+                             unsigned int phase) const override;
+  Probability evaluateSequence(CEPtr<Labeling> evaluator,
+                               unsigned int begin,
+                               unsigned int end,
+                               unsigned int phase) const override;
 
   Probability evaluateSymbol(SEPtr<Labeling> evaluator,
                              unsigned int pos,
                              unsigned int phase) const override;
   Probability evaluateSequence(SEPtr<Labeling> evaluator,
-                               unsigned int begin,
-                               unsigned int end,
-                               unsigned int phase) const override;
-
-  Probability evaluateSymbol(CEPtr<Labeling> evaluator,
-                             unsigned int pos,
-                             unsigned int phase) const override;
-  Probability evaluateSequence(CEPtr<Labeling> evaluator,
                                unsigned int begin,
                                unsigned int end,
                                unsigned int phase) const override;
@@ -130,25 +129,24 @@ class HiddenMarkovModel
                                   unsigned int size,
                                   unsigned int phase) const override;
 
-  Estimation<Labeling<Sequence>> labeling(
-      SLPtr<Standard> labeler,
-      Labeling<Sequence>::Method method) const override;
-
+  void initializeCache(CLPtr<Standard> labeler,
+                       unsigned int phase) override;
   Estimation<Labeling<Sequence>> labeling(
       CLPtr<Standard> labeler,
       Labeling<Sequence>::Method method) const override;
 
-  void initializeCache(CLPtr<Standard> labeler,
-                       unsigned int phase) override;
+  Estimation<Labeling<Sequence>> labeling(
+      SLPtr<Standard> labeler,
+      Labeling<Sequence>::Method method) const override;
 
-  // Virtual methods
-  virtual double backward(const Sequence &sequence,
-                          Matrix &beta) const override;
-  virtual double forward(const Sequence &sequence,
-                         Matrix &alpha) const override;
-  virtual void posteriorProbabilities(const Sequence &sequence,
-                                      Matrix &probabilities) const override;
+  double backward(const Sequence &sequence,
+                  Matrix &beta) const override;
+  double forward(const Sequence &sequence,
+                 Matrix &alpha) const override;
+  void posteriorProbabilities(const Sequence &sequence,
+                              Matrix &probabilities) const override;
 
+  // Concrete methods
   unsigned int stateAlphabetSize() const;
   unsigned int observationAlphabetSize() const;
   HiddenMarkovModelStatePtr state(unsigned int i) const;

--- a/include/model/HiddenMarkovModel.hpp
+++ b/include/model/HiddenMarkovModel.hpp
@@ -167,7 +167,8 @@ class HiddenMarkovModel
   posteriorDecoding(const Sequence &xs, Matrix &probabilities) const override;
 
   // Concrete methods
-  void initializePrefixSumArray(const Sequence &sequence, Cache &cache);
+  void initializeStandardPrefixSumArray(const Sequence &sequence, Cache &cache);
+  void initializeLabelingPrefixSumArray(CEPtr<Labeling> evaluator, unsigned int phase);
 };
 
 }  // namespace model

--- a/src/model/HiddenMarkovModel.cpp
+++ b/src/model/HiddenMarkovModel.cpp
@@ -222,7 +222,7 @@ HiddenMarkovModelPtr HiddenMarkovModel::trainBaumWelch(
 
 void HiddenMarkovModel::initializeCache(CEPtr<Standard> evaluator,
                                         unsigned int /* phase */) {
-  initializeCache(evaluator->sequence(), evaluator->cache());
+  initializePrefixSumArray(evaluator->sequence(), evaluator->cache());
 }
 
 /*----------------------------------------------------------------------------*/
@@ -277,9 +277,9 @@ HiddenMarkovModel::evaluateSequence(CEPtr<Standard> evaluator,
 
 /*----------------------------------------------------------------------------*/
 
-void HiddenMarkovModel::initializeCache(CEPtr<Labeling> evaluator,
+void HiddenMarkovModel::initializeCache(CEPtr<Labeling> /*evaluator*/,
                                         unsigned int /* phase */) {
-  initializeCache(evaluator->sequence().observation(), evaluator->cache());
+  // TODO(igorbonadio)
 }
 
 /*----------------------------------------------------------------------------*/
@@ -405,9 +405,9 @@ Estimation<Labeling<Sequence>> HiddenMarkovModel::labeling(
 
 /*----------------------------------------------------------------------------*/
 
-void HiddenMarkovModel::initializeCache(CLPtr<Standard> labeler,
+void HiddenMarkovModel::initializeCache(CLPtr<Standard> /*labeler*/,
                                         unsigned int /*phase*/) {
-  initializeCache(labeler->sequence(), labeler->cache());
+  // TODO(igorbonadio)
 }
 
 /*----------------------------------------------------------------------------*/
@@ -575,30 +575,6 @@ void HiddenMarkovModel::posteriorProbabilities(const Sequence &sequence,
 
 /*================================  OTHERS  ==================================*/
 
-// Estimation<Labeling<Sequence>>
-// HiddenMarkovModel::simpleLabeling(SEPtr evaluator,
-//                                   Labeling<Sequence>::Method method) {
-//   Matrix matrix;
-//   return labeling(evaluator->sequence(), matrix, method);
-// }
-
-/*----------------------------------------------------------------------------*/
-
-// Estimation<Labeling<Sequence>>
-// HiddenMarkovModel::cachedLabeling(CEPtr evaluator,
-//                                   Labeling<Sequence>::Method method) {
-//   switch (method) {
-//     case Labeling<Sequence>::Method::bestPath:
-//       return labeling(evaluator->sequence(), evaluator->cache().gamma, method);
-//     case Labeling<Sequence>::Method::posteriorDecoding:
-//       return labeling(evaluator->sequence(),
-//                       evaluator->cache().posterior_decoding,
-//                       method);
-//   }
-//   // TODO(renatocf): throw exception
-//   return Estimation<Labeling<Sequence>>();
-// }
-
 /*----------------------------------------------------------------------------*/
 
 HiddenMarkovModelStatePtr HiddenMarkovModel::state(unsigned int i) const {
@@ -619,8 +595,8 @@ unsigned int HiddenMarkovModel::observationAlphabetSize() const {
 
 /*----------------------------------------------------------------------------*/
 
-void HiddenMarkovModel::initializeCache(const Sequence &sequence,
-                                        Cache &cache) {
+void HiddenMarkovModel::initializePrefixSumArray(const Sequence &sequence,
+                                                 Cache &cache) {
   cache.prefix_sum_array.resize(sequence.size()+1);
   forward(sequence, cache.alpha);
   cache.prefix_sum_array[0] = 0;

--- a/src/model/HiddenMarkovModel.cpp
+++ b/src/model/HiddenMarkovModel.cpp
@@ -392,13 +392,11 @@ Estimation<Labeling<Sequence>> HiddenMarkovModel::labeling(
 
 Estimation<Labeling<Sequence>> HiddenMarkovModel::labeling(
     CLPtr<Standard> labeler, Labeling<Sequence>::Method method) const {
-  // TODOigorbonadio): Use cache...
-  Matrix probabilities;
   switch (method) {
     case Labeling<Sequence>::Method::bestPath:
-      return viterbi(labeler->sequence(), probabilities);
+      return viterbi(labeler->sequence(), labeler->cache().gamma);
     case Labeling<Sequence>::Method::posteriorDecoding:
-      return posteriorDecoding(labeler->sequence(), probabilities);
+      return posteriorDecoding(labeler->sequence(), labeler->cache().posterior_decoding);
   }
   return Estimation<Labeling<Sequence>>();
 }

--- a/src/model/HiddenMarkovModel.cpp
+++ b/src/model/HiddenMarkovModel.cpp
@@ -228,6 +228,26 @@ void HiddenMarkovModel::initializeCache(CEPtr<Standard> evaluator,
 /*----------------------------------------------------------------------------*/
 
 Probability
+HiddenMarkovModel::evaluateSymbol(CEPtr<Standard> /* evaluator */,
+                                  unsigned int /* pos */,
+                                  unsigned int /* phase */) const {
+  return -std::numeric_limits<double>::infinity(); // TODO(igorbonadio)
+}
+
+/*----------------------------------------------------------------------------*/
+
+Probability
+HiddenMarkovModel::evaluateSequence(CEPtr<Standard> evaluator,
+                                    unsigned int begin,
+                                    unsigned int end,
+                                    unsigned int /* phase */) const {
+  return evaluator->cache().prefix_sum_array[end]
+         - evaluator->cache().prefix_sum_array[begin];
+}
+
+/*----------------------------------------------------------------------------*/
+
+Probability
 HiddenMarkovModel::evaluateSymbol(SEPtr<Standard> /* evaluator */,
                                   unsigned int /* pos */,
                                   unsigned int /* phase */) const {
@@ -257,29 +277,29 @@ HiddenMarkovModel::evaluateSequence(SEPtr<Standard> evaluator,
 
 /*----------------------------------------------------------------------------*/
 
-Probability
-HiddenMarkovModel::evaluateSymbol(CEPtr<Standard> /* evaluator */,
-                                  unsigned int /* pos */,
-                                  unsigned int /* phase */) const {
-  return -std::numeric_limits<double>::infinity(); // TODO(igorbonadio)
-}
-
-/*----------------------------------------------------------------------------*/
-
-Probability
-HiddenMarkovModel::evaluateSequence(CEPtr<Standard> evaluator,
-                                    unsigned int begin,
-                                    unsigned int end,
-                                    unsigned int /* phase */) const {
-  return evaluator->cache().prefix_sum_array[end]
-         - evaluator->cache().prefix_sum_array[begin];
-}
-
-/*----------------------------------------------------------------------------*/
-
 void HiddenMarkovModel::initializeCache(CEPtr<Labeling> /*evaluator*/,
                                         unsigned int /* phase */) {
   // TODO(igorbonadio)
+}
+
+/*----------------------------------------------------------------------------*/
+
+Probability
+HiddenMarkovModel::evaluateSymbol(CEPtr<Labeling> evaluator,
+                                  unsigned int pos,
+                                  unsigned int phase) const {
+  return evaluateSymbol(static_cast<SEPtr<Labeling>>(evaluator), pos, phase);
+}
+
+/*----------------------------------------------------------------------------*/
+
+Probability
+HiddenMarkovModel::evaluateSequence(CEPtr<Labeling> evaluator,
+                                    unsigned int begin,
+                                    unsigned int end,
+                                    unsigned int phase) const {
+  return evaluateSequence(
+    static_cast<SEPtr<Labeling>>(evaluator), begin, end, phase);
 }
 
 /*----------------------------------------------------------------------------*/
@@ -315,26 +335,6 @@ HiddenMarkovModel::evaluateSequence(SEPtr<Labeling> evaluator,
   for (unsigned int i = begin; i < end; i++)
     prob += evaluateSymbol(evaluator, i, phase);
   return prob;
-}
-
-/*----------------------------------------------------------------------------*/
-
-Probability
-HiddenMarkovModel::evaluateSymbol(CEPtr<Labeling> evaluator,
-                                  unsigned int pos,
-                                  unsigned int phase) const {
-  return evaluateSymbol(static_cast<SEPtr<Labeling>>(evaluator), pos, phase);
-}
-
-/*----------------------------------------------------------------------------*/
-
-Probability
-HiddenMarkovModel::evaluateSequence(CEPtr<Labeling> evaluator,
-                                    unsigned int begin,
-                                    unsigned int end,
-                                    unsigned int phase) const {
-  return evaluateSequence(
-    static_cast<SEPtr<Labeling>>(evaluator), begin, end, phase);
 }
 
 /*===============================  GENERATOR  ================================*/

--- a/test/model/HiddenMarkovModelTest.cpp
+++ b/test/model/HiddenMarkovModelTest.cpp
@@ -64,6 +64,12 @@ TEST_F(AHiddenMarkovModel, ShouldEvaluateTheJointProbability) {
               DoubleEq(log(0.9) + log(0.5) +
                        log(0.3) + log(0.2) +
                        log(0.5) + log(0.8)));
+}
+
+TEST_F(AHiddenMarkovModel, ShouldEvaluateTheJointProbabilityWithCache) {
+  Sequence observation {0, 0, 1};
+  Sequence label       {0, 1, 1};
+  Labeling<Sequence> labeling(observation, label);
 
   ASSERT_THAT(hmm->labelingEvaluator(labeling, true)->evaluateSequence(0, 3),
               DoubleEq(log(0.9) + log(0.5) +
@@ -103,7 +109,7 @@ TEST_F(AHiddenMarkovModel, FindsTheBestPathWithCache) {
   }
 }
 
-TEST_F(AHiddenMarkovModel, CalculatesProbabilityOfObservationsUsingForward) {
+TEST_F(AHiddenMarkovModel, CalculatesProbabilityOfObservations) {
   std::vector<Sequence> test_set = {
     {0},
     {1},

--- a/test/model/HiddenMarkovModelTest.cpp
+++ b/test/model/HiddenMarkovModelTest.cpp
@@ -64,6 +64,11 @@ TEST_F(AHiddenMarkovModel, ShouldEvaluateTheJointProbability) {
               DoubleEq(log(0.9) + log(0.5) +
                        log(0.3) + log(0.2) +
                        log(0.5) + log(0.8)));
+
+  ASSERT_THAT(hmm->labelingEvaluator(labeling, true)->evaluateSequence(0, 3),
+              DoubleEq(log(0.9) + log(0.5) +
+                       log(0.3) + log(0.2) +
+                       log(0.5) + log(0.8)));
 }
 
 TEST_F(AHiddenMarkovModel, FindsTheBestPath) {


### PR DESCRIPTION
`prefix_sum_array` behaves differently in `*<Standard>` and `*<Labeling>`
