### PR TITLE
Close #49 (Virtual destructors)

### DIFF
--- a/doc/GUARD.cpp
+++ b/doc/GUARD.cpp
@@ -71,16 +71,18 @@
   // Tags
   // Alias
   // Type traits
+  // Enum classes
   // Inner classes
-  // Hidden name method inheritance
+  // Static variables
   // Instance variables
+  // Hidden name inheritance
   // Constructors
   // Static methods
   // Overriden methods
-  // Purely Virtual methods
+  // Purely virtual methods
   // Virtual methods
   // Concrete methods
-  // Instance variables
+  // Destructor
 
 /*
 \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\

--- a/include/model/Calculator.hpp
+++ b/include/model/Calculator.hpp
@@ -54,6 +54,9 @@ class Calculator : public std::enable_shared_from_this<Calculator> {
 
   virtual Sequence& sequence() = 0;
   virtual const Sequence& sequence() const = 0;
+
+  // Destructor
+  virtual ~Calculator() = default;
 };
 
 }  // namespace model

--- a/include/model/DecodableModel.hpp
+++ b/include/model/DecodableModel.hpp
@@ -60,6 +60,9 @@ class DecodableModel : public virtual ProbabilisticModel {
 
   virtual CalculatorPtr calculator(
       const Sequence &sequence, bool cached = false) = 0;
+
+  // Destructor
+  virtual ~DecodableModel() = default;
 };
 
 }  // namespace model

--- a/include/model/Duration.hpp
+++ b/include/model/Duration.hpp
@@ -52,6 +52,9 @@ class Duration {
   virtual RangePtr range() const = 0;
   virtual unsigned int maximumSize() const = 0;
   virtual Probability probabilityOfLenght(unsigned int length) const = 0;
+
+  // Destructor
+  virtual ~Duration() = default;
 };
 
 }  // namespace model

--- a/include/model/Evaluator.hpp
+++ b/include/model/Evaluator.hpp
@@ -58,6 +58,9 @@ class Evaluator
 
   virtual Decorator<Sequence>& sequence() = 0;
   virtual const Decorator<Sequence>& sequence() const = 0;
+
+  // Destructor
+  virtual ~Evaluator() = default;
 };
 
 }  // namespace model

--- a/include/model/Generator.hpp
+++ b/include/model/Generator.hpp
@@ -59,6 +59,9 @@ class Generator : public std::enable_shared_from_this<Generator<Decorator>> {
                                            unsigned int phase = 0) const = 0;
 
   virtual RandomNumberGeneratorPtr randomNumberGenerator() const = 0;
+
+  // Destructor
+  virtual ~Generator() = default;
 };
 
 }  // namespace model

--- a/include/model/Labeler.hpp
+++ b/include/model/Labeler.hpp
@@ -55,6 +55,9 @@ class Labeler : public std::enable_shared_from_this<Labeler> {
 
   virtual Sequence& sequence() = 0;
   virtual const Sequence& sequence() const = 0;
+
+  // Destructor
+  virtual ~Labeler() = default;
 };
 
 }  // namespace model

--- a/include/model/ProbabilisticModel.hpp
+++ b/include/model/ProbabilisticModel.hpp
@@ -59,6 +59,9 @@ class ProbabilisticModel {
       RandomNumberGeneratorPtr rng = RNGAdapter<std::mt19937>::make()) = 0;
 
   virtual SerializerPtr serializer(TranslatorPtr translator) = 0;
+
+  // Destructor
+  virtual ~ProbabilisticModel() = default;
 };
 
 }  // namespace model

--- a/include/model/RandomNumberGenerator.hpp
+++ b/include/model/RandomNumberGenerator.hpp
@@ -49,6 +49,9 @@ class RandomNumberGenerator {
   virtual result_type operator()() = 0;
   virtual void discard(uint64_t z) = 0;
   virtual double generateDoubleInUnitInterval() = 0;
+
+  // Destructor
+  virtual ~RandomNumberGenerator() = default;
 };
 
 }  // namespace model

--- a/include/model/Range.hpp
+++ b/include/model/Range.hpp
@@ -45,6 +45,9 @@ class Range {
   virtual unsigned int begin() = 0;
   virtual unsigned int next() = 0;
   virtual bool end() = 0;
+
+  // Destructor
+  virtual ~Range() = default;
 };
 
 }  // namespace model

--- a/include/model/Serializer.hpp
+++ b/include/model/Serializer.hpp
@@ -48,6 +48,9 @@ class Serializer : public std::enable_shared_from_this<Serializer> {
   virtual void serialize() = 0;
 
   virtual TranslatorPtr translator() = 0;
+
+  // Destructor
+  virtual ~Serializer() = default;
 };
 
 }  // namespace model

--- a/include/model/State.hpp
+++ b/include/model/State.hpp
@@ -71,6 +71,9 @@ class State {
   virtual void addSuccessor(Id id) = 0;
   virtual std::vector<Id>& successors() = 0;
   virtual const std::vector<Id>& successors() const = 0;
+
+  // Destructor
+  virtual ~State() = default;
 };
 
 }  // namespace model

--- a/include/model/Trainer.hpp
+++ b/include/model/Trainer.hpp
@@ -75,6 +75,9 @@ class Trainer
     CALL_STATIC_MEMBER_FUNCTION_DELEGATOR(train, std::forward<Args>(args)...);
   }
 
+  // Destructor
+  virtual ~Trainer() = default;
+
  protected:
   // Purely virtual methods
   virtual bool delegate() const = 0;

--- a/include/model/Translator.hpp
+++ b/include/model/Translator.hpp
@@ -89,6 +89,9 @@ class Translator : public std::enable_shared_from_this<Translator> {
   virtual void translate(Ptr<SignalDuration> duration) = 0;
   virtual void translate(Ptr<ExplicitDuration> duration) = 0;
   virtual void translate(Ptr<GeometricDuration> duration) = 0;
+
+  // Destructor
+  virtual ~Translator() = default;
 };
 
 }  // namespace model


### PR DESCRIPTION
@igorbonadio,

This pull request is aimed to fix #49, creating virtual destructors for all ToPS interfaces. This way, we'll be able to safely use all concrete `ProbabilisticModel`s, front-ends, `State`s, `Range`s and `Duration`s through their base pointers.
