### PR TITLE
Warnings

### DIFF
--- a/Config.mk
+++ b/Config.mk
@@ -47,7 +47,7 @@ LDLIBS          +=
 CPPFLAGS        += # Precompiler Flags
 ASFLAGS         += # Assembly Flags
 CFLAGS          += # C Flags
-CXXFLAGS        += -std=c++14 -Wall -Wextra -Werror -pedantic -O2
+CXXFLAGS        += -std=c++14 -Wall -Wextra -Wshadow -Werror -pedantic -O2
 LDFLAGS         +=
 
 # Makeball list

--- a/Config.mk
+++ b/Config.mk
@@ -1,7 +1,7 @@
 
-########################################################################
-##                    ToPS Makefile Configuration                     ##
-########################################################################
+##############################################################################
+##                        ToPS Makefile Configuration                       ##
+##############################################################################
 
 # Project settings
 # ==================
@@ -24,31 +24,23 @@ DESCRIPTION     := ToPS is an objected-oriented framework that \
 
 # Program settings
 # ==================
-BIN             :=
 SHRLIB          := model
 TESTBIN         := test
 BENCHBIN        := bench
 
-# Dependencies
-# ==============
-GIT_DEPENDENCY  +=
-WEB_DEPENDENCY  += # Same as above, but for URL downloads
-                   # with 'curl -o' (default) or 'wget -O'
-
 # Paths
 # =======
-ASLIBS          += # Assembly paths
-CLIBS           += # C paths
-CXXLIBS         +=
-LDLIBS          +=
+CXXLIBS         += # C++ paths
+LDLIBS          += # Linker paths
 
 # Flags
 # =======
 CPPFLAGS        += # Precompiler Flags
-ASFLAGS         += # Assembly Flags
-CFLAGS          += # C Flags
-CXXFLAGS        += -std=c++14 -Wall -Wextra -Wshadow -Wcast-align -Werror -Wold-style-cast -Wmissing-include-dirs -Wredundant-decls -pedantic -O2
-LDFLAGS         +=
+CXXFLAGS        += -std=c++14 \
+                   -Wall -Wextra -Wpedantic -Wshadow -Wold-style-cast \
+                   -Wcast-align -Wmissing-include-dirs -Wredundant-decls \
+                   -Werror -O2
+LDFLAGS         += # Linker Flags
 
 # Makeball list
 # ===============

--- a/Config.mk
+++ b/Config.mk
@@ -47,7 +47,7 @@ LDLIBS          +=
 CPPFLAGS        += # Precompiler Flags
 ASFLAGS         += # Assembly Flags
 CFLAGS          += # C Flags
-CXXFLAGS        += -ansi -Wall -Wextra -Werror -pedantic -O2 -std=c++14
+CXXFLAGS        += -std=c++14 -Wall -Wextra -Werror -pedantic -O2
 LDFLAGS         +=
 
 # Makeball list

--- a/Config.mk
+++ b/Config.mk
@@ -47,7 +47,7 @@ LDLIBS          +=
 CPPFLAGS        += # Precompiler Flags
 ASFLAGS         += # Assembly Flags
 CFLAGS          += # C Flags
-CXXFLAGS        += -std=c++14 -Wall -Wextra -Wshadow -Wcast-align -Werror -Wold-style-cast -pedantic -O2
+CXXFLAGS        += -std=c++14 -Wall -Wextra -Wshadow -Wcast-align -Werror -Wold-style-cast -Wmissing-include-dirs -pedantic -O2
 LDFLAGS         +=
 
 # Makeball list

--- a/Config.mk
+++ b/Config.mk
@@ -47,7 +47,7 @@ LDLIBS          +=
 CPPFLAGS        += # Precompiler Flags
 ASFLAGS         += # Assembly Flags
 CFLAGS          += # C Flags
-CXXFLAGS        += -std=c++14 -Wall -Wextra -Wshadow -Wcast-align -Werror -Wold-style-cast -Wmissing-include-dirs -pedantic -O2
+CXXFLAGS        += -std=c++14 -Wall -Wextra -Wshadow -Wcast-align -Werror -Wold-style-cast -Wmissing-include-dirs -Wredundant-decls -pedantic -O2
 LDFLAGS         +=
 
 # Makeball list

--- a/Config.mk
+++ b/Config.mk
@@ -47,7 +47,7 @@ LDLIBS          +=
 CPPFLAGS        += # Precompiler Flags
 ASFLAGS         += # Assembly Flags
 CFLAGS          += # C Flags
-CXXFLAGS        += -std=c++14 -Wall -Wextra -Wshadow -Werror -pedantic -O2
+CXXFLAGS        += -std=c++14 -Wall -Wextra -Wshadow -Wcast-align -Werror -pedantic -O2
 LDFLAGS         +=
 
 # Makeball list

--- a/Config.mk
+++ b/Config.mk
@@ -47,7 +47,7 @@ LDLIBS          +=
 CPPFLAGS        += # Precompiler Flags
 ASFLAGS         += # Assembly Flags
 CFLAGS          += # C Flags
-CXXFLAGS        += -std=c++14 -Wall -Wextra -Wshadow -Wcast-align -Werror -pedantic -O2
+CXXFLAGS        += -std=c++14 -Wall -Wextra -Wshadow -Wcast-align -Werror -Wold-style-cast -pedantic -O2
 LDFLAGS         +=
 
 # Makeball list

--- a/doc/GUARD.cpp
+++ b/doc/GUARD.cpp
@@ -71,16 +71,18 @@
   // Tags
   // Alias
   // Type traits
+  // Enum classes
   // Inner classes
-  // Hidden name method inheritance
+  // Static variables
   // Instance variables
+  // Hidden name inheritance
   // Constructors
   // Static methods
   // Overriden methods
-  // Purely Virtual methods
+  // Purely virtual methods
   // Virtual methods
   // Concrete methods
-  // Instance variables
+  // Destructor
 
 /*
 \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\

--- a/include/model/CachedCalculator.hpp
+++ b/include/model/CachedCalculator.hpp
@@ -65,9 +65,10 @@ class CachedCalculator : public SimpleCalculator<Model> {
   }
 
   // Overriden methods
-  Probability calculate(const Calculator::direction& direction) const override {
+  Probability
+  calculate(const Calculator::direction& chosen_direction) const override {
     lazyInitializeCache();
-    CALL_MEMBER_FUNCTION_DELEGATOR(calculate, direction);
+    CALL_MEMBER_FUNCTION_DELEGATOR(calculate, chosen_direction);
   }
 
   // Virtual methods

--- a/include/model/CachedLabeler.hpp
+++ b/include/model/CachedLabeler.hpp
@@ -66,9 +66,9 @@ class CachedLabeler : public SimpleLabeler<Model> {
 
   // Overriden methods
   Estimation<Labeling<Sequence>>
-  labeling(const Labeler::method& method) const override {
+  labeling(const Labeler::method& chosen_method) const override {
     lazyInitializeCache();
-    CALL_MEMBER_FUNCTION_DELEGATOR(labeling, method);
+    CALL_MEMBER_FUNCTION_DELEGATOR(labeling, chosen_method);
   }
 
   // Virtual methods

--- a/include/model/Calculator.hpp
+++ b/include/model/Calculator.hpp
@@ -54,6 +54,9 @@ class Calculator : public std::enable_shared_from_this<Calculator> {
 
   virtual Sequence& sequence() = 0;
   virtual const Sequence& sequence() const = 0;
+
+  // Destructor
+  virtual ~Calculator() = default;
 };
 
 }  // namespace model

--- a/include/model/DecodableModel.hpp
+++ b/include/model/DecodableModel.hpp
@@ -60,6 +60,9 @@ class DecodableModel : public virtual ProbabilisticModel {
 
   virtual CalculatorPtr calculator(
       const Sequence &sequence, bool cached = false) = 0;
+
+  // Destructor
+  virtual ~DecodableModel() = default;
 };
 
 }  // namespace model

--- a/include/model/Duration.hpp
+++ b/include/model/Duration.hpp
@@ -52,6 +52,9 @@ class Duration {
   virtual RangePtr range() const = 0;
   virtual unsigned int maximumSize() const = 0;
   virtual Probability probabilityOfLenght(unsigned int length) const = 0;
+
+  // Destructor
+  virtual ~Duration() = default;
 };
 
 }  // namespace model

--- a/include/model/Evaluator.hpp
+++ b/include/model/Evaluator.hpp
@@ -58,6 +58,9 @@ class Evaluator
 
   virtual Decorator<Sequence>& sequence() = 0;
   virtual const Decorator<Sequence>& sequence() const = 0;
+
+  // Destructor
+  virtual ~Evaluator() = default;
 };
 
 }  // namespace model

--- a/include/model/Generator.hpp
+++ b/include/model/Generator.hpp
@@ -59,6 +59,9 @@ class Generator : public std::enable_shared_from_this<Generator<Decorator>> {
                                            unsigned int phase = 0) const = 0;
 
   virtual RandomNumberGeneratorPtr randomNumberGenerator() const = 0;
+
+  // Destructor
+  virtual ~Generator() = default;
 };
 
 }  // namespace model

--- a/include/model/Labeler.hpp
+++ b/include/model/Labeler.hpp
@@ -55,6 +55,9 @@ class Labeler : public std::enable_shared_from_this<Labeler> {
 
   virtual Sequence& sequence() = 0;
   virtual const Sequence& sequence() const = 0;
+
+  // Destructor
+  virtual ~Labeler() = default;
 };
 
 }  // namespace model

--- a/include/model/MemberDelegator.hpp
+++ b/include/model/MemberDelegator.hpp
@@ -52,7 +52,7 @@ using non_const_return_t = typename non_const_return<T>::type;
 
 template<typename T>
 non_const_return_t<T> non_const_cast(T t) {
-    return (non_const_return_t<T>) t;
+  return static_cast<non_const_return_t<T>>(t);
 }
 
 /*============================================================================*/
@@ -133,7 +133,7 @@ inline auto method##Impl(Args&&... args) const                                 \
 template<typename... Args>                                                     \
 inline auto method##Impl(Args&&... args)                                       \
     -> decltype(this->method(std::forward<Args>(args)...)) {                   \
-  return (non_const_return_t<decltype(this->method(args...))>) (               \
+  return static_cast<non_const_return_t<decltype(this->method(args...))>>(     \
     static_cast<const class_of_t<decltype(this)> *>(this)->method##Impl(       \
       std::forward<Args>(args)...));                                           \
 }
@@ -169,8 +169,8 @@ inline auto method##Impl(Args&&... args) const                                 \
 template<typename... Args>                                                     \
 inline auto method##Impl(Args&&... args)                                       \
     -> decltype(this->method(std::forward<Args>(args)...)) {                   \
-  return (non_const_return_t<                                                  \
-            decltype(this->method(std::forward<Args>(args)...))>) (            \
+  return static_cast<non_const_return_t<                                       \
+            decltype(this->method(std::forward<Args>(args)...))>>(             \
     static_cast<const class_of_t<decltype(this)> *>(this)->method##Impl(       \
       std::forward<Args>(args)...));                                           \
 }                                                                              \
@@ -182,7 +182,7 @@ inline auto method##Impl() const                                               \
                                                                                \
 inline auto method##Impl()                                                     \
     -> decltype(this->method()) {                                              \
-  return (non_const_return_t<decltype(this->method())>) (                      \
+  return static_cast<non_const_return_t<decltype(this->method())>>(            \
     static_cast<const class_of_t<decltype(this)>*>(this)->method##Impl());     \
 }                                                                              \
                                                                                \
@@ -205,7 +205,7 @@ inline constexpr auto method##Alt(_T* = nullptr)                               \
                   >::value                                                     \
                 >::type(),                                                     \
                 non_const_cast(this)->method()) {                              \
-  return (non_const_return_t<decltype(this->method())>) (                      \
+  return static_cast<non_const_return_t<decltype(this->method())>>(            \
     static_cast<const class_of_t<decltype(this)>*>(this)->method##Impl());     \
 }                                                                              \
                                                                                \
@@ -226,7 +226,7 @@ inline constexpr auto delegate(_T* = nullptr)                                  \
                     class_of_t<decltype(this)>, void()                         \
                   >::value                                                     \
                 >::type(), bool()) {                                           \
-  return (non_const_return_t<decltype(this->method())>) (                      \
+  return static_cast<non_const_return_t<decltype(this->method())>>(            \
     static_cast<const class_of_t<decltype(this)>*>(this)->method##Impl());     \
 }
 

--- a/include/model/ProbabilisticModel.hpp
+++ b/include/model/ProbabilisticModel.hpp
@@ -59,6 +59,9 @@ class ProbabilisticModel {
       RandomNumberGeneratorPtr rng = RNGAdapter<std::mt19937>::make()) = 0;
 
   virtual SerializerPtr serializer(TranslatorPtr translator) = 0;
+
+  // Destructor
+  virtual ~ProbabilisticModel() = default;
 };
 
 }  // namespace model

--- a/include/model/RandomNumberGenerator.hpp
+++ b/include/model/RandomNumberGenerator.hpp
@@ -49,6 +49,9 @@ class RandomNumberGenerator {
   virtual result_type operator()() = 0;
   virtual void discard(uint64_t z) = 0;
   virtual double generateDoubleInUnitInterval() = 0;
+
+  // Destructor
+  virtual ~RandomNumberGenerator() = default;
 };
 
 }  // namespace model

--- a/include/model/Range.hpp
+++ b/include/model/Range.hpp
@@ -45,6 +45,9 @@ class Range {
   virtual unsigned int begin() = 0;
   virtual unsigned int next() = 0;
   virtual bool end() = 0;
+
+  // Destructor
+  virtual ~Range() = default;
 };
 
 }  // namespace model

--- a/include/model/Serializer.hpp
+++ b/include/model/Serializer.hpp
@@ -48,6 +48,9 @@ class Serializer : public std::enable_shared_from_this<Serializer> {
   virtual void serialize() = 0;
 
   virtual TranslatorPtr translator() = 0;
+
+  // Destructor
+  virtual ~Serializer() = default;
 };
 
 }  // namespace model

--- a/include/model/SimpleCalculator.hpp
+++ b/include/model/SimpleCalculator.hpp
@@ -62,8 +62,9 @@ class SimpleCalculator : public Calculator {
   }
 
   // Overriden methods
-  Probability calculate(const Calculator::direction& direction) const override {
-    CALL_MEMBER_FUNCTION_DELEGATOR(calculate, direction);
+  Probability
+  calculate(const Calculator::direction& chosen_direction) const override {
+    CALL_MEMBER_FUNCTION_DELEGATOR(calculate, chosen_direction);
   }
 
   Sequence& sequence() override {

--- a/include/model/SimpleLabeler.hpp
+++ b/include/model/SimpleLabeler.hpp
@@ -63,8 +63,8 @@ class SimpleLabeler : public Labeler {
 
   // Overriden methods
   Estimation<Labeling<Sequence>>
-  labeling(const Labeler::method& method) const override {
-    CALL_MEMBER_FUNCTION_DELEGATOR(labeling, method);
+  labeling(const Labeler::method& chosen_method) const override {
+    CALL_MEMBER_FUNCTION_DELEGATOR(labeling, chosen_method);
   }
 
   Sequence& sequence() override {

--- a/include/model/State.hpp
+++ b/include/model/State.hpp
@@ -71,6 +71,9 @@ class State {
   virtual void addSuccessor(Id id) = 0;
   virtual std::vector<Id>& successors() = 0;
   virtual const std::vector<Id>& successors() const = 0;
+
+  // Destructor
+  virtual ~State() = default;
 };
 
 }  // namespace model

--- a/include/model/Trainer.hpp
+++ b/include/model/Trainer.hpp
@@ -75,6 +75,9 @@ class Trainer
     CALL_STATIC_MEMBER_FUNCTION_DELEGATOR(train, std::forward<Args>(args)...);
   }
 
+  // Destructor
+  virtual ~Trainer() = default;
+
  protected:
   // Purely virtual methods
   virtual bool delegate() const = 0;

--- a/include/model/Translator.hpp
+++ b/include/model/Translator.hpp
@@ -89,6 +89,9 @@ class Translator : public std::enable_shared_from_this<Translator> {
   virtual void translate(Ptr<SignalDuration> duration) = 0;
   virtual void translate(Ptr<ExplicitDuration> duration) = 0;
   virtual void translate(Ptr<GeometricDuration> duration) = 0;
+
+  // Destructor
+  virtual ~Translator() = default;
 };
 
 }  // namespace model

--- a/src/model/HiddenMarkovModel.cpp
+++ b/src/model/HiddenMarkovModel.cpp
@@ -81,12 +81,14 @@ HiddenMarkovModel::train(TrainerPtr<Standard, Self> trainer,
       Probability P = model->forward(observation_training_set[s], alpha);
       model->backward(observation_training_set[s], beta);
 
-      Probability sum = alpha[0][0] + beta[0][0];
-      for (unsigned int i = 1; i < state_alphabet_size; i++)
-        sum = log_sum(sum, alpha[i][0] + beta[i][0]);
+      {
+        Probability sum = alpha[0][0] + beta[0][0];
+        for (unsigned int i = 1; i < state_alphabet_size; i++)
+          sum = log_sum(sum, alpha[i][0] + beta[i][0]);
 
-      for (unsigned int i = 0; i < state_alphabet_size; i++)
-        pi[i] = alpha[i][0] + beta[i][0] - sum;
+        for (unsigned int i = 0; i < state_alphabet_size; i++)
+          pi[i] = alpha[i][0] + beta[i][0] - sum;
+      }
 
       for (unsigned int i = 0; i < state_alphabet_size; i++) {
         for (unsigned int j = 0; j < state_alphabet_size; j++) {


### PR DESCRIPTION
@igorbonadio,

I added some new warning flags for gcc/clang to use in compilation. The most important, I guess, are `-Wshadow`, which revealed some repeated variable declarations within our algorithms, and `-Wold-style-cast`, which made me remove C-style casts from within (static) member delegator macros. Besides, I added `-Wcast-align`, `-Wmissing-include-dirs`, and `-Wredundant-decls`. You can take a look on what they do exactly on gcc's man page. I think we can use this extra warnings from now on.

Please, accept #58 before merging this pull request.

I also wanted to add `-Wfloat-equal`, which warns about equality (`==`) and inequality (`!=`) comparisons made with floating-point variables. As we know, floating-point arithmetic is an approximation, and therefore such comparisons are hardly true. The correct way of checking this is verifying the difference with an epsilon error. I found this problem on `ContextTreeNode` implementation. As floating-point comparison is a non-trivial thing (accordingly to [this](http://stackoverflow.com/questions/17333/most-effective-way-for-float-and-double-comparison) and [this](http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm)), I decided to create a specific issue.
