### PR TITLE
Close #18 (Code style)

### DIFF
--- a/include/helper/SExprTranslator.hpp
+++ b/include/helper/SExprTranslator.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <string>
 
-// ToPS headers
+// Internal headers
 #include "model/DiscreteIIDModel.hpp"
 #include "model/FixedSequenceAtPosition.hpp"
 #include "model/GeneralizedHiddenMarkovModel.hpp"

--- a/include/helper/Sequence.hpp
+++ b/include/helper/Sequence.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Sequence.hpp"
 
 namespace tops {

--- a/include/model/CachedCalculator.hpp
+++ b/include/model/CachedCalculator.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <type_traits>
 
-// ToPS headers
+// Internal headers
 #include "model/Labeling.hpp"
 #include "model/Sequence.hpp"
 #include "model/Estimation.hpp"

--- a/include/model/CachedEvaluator.hpp
+++ b/include/model/CachedEvaluator.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <type_traits>
 
-// ToPS headers
+// Internal headers
 #include "model/Labeling.hpp"
 #include "model/Sequence.hpp"
 #include "model/Estimation.hpp"

--- a/include/model/CachedEvaluator.hpp
+++ b/include/model/CachedEvaluator.hpp
@@ -67,14 +67,14 @@ class CachedEvaluator : public SimpleEvaluator<Decorator, Model> {
   // Overriden methods
   Probability evaluateSymbol(unsigned int pos,
                              unsigned int phase) const override {
-    const_cast<Self *>(this)->lazyInitializeCache(phase);
+    const_cast<Self*>(this)->lazyInitializeCache(phase);
     CALL_MEMBER_FUNCTION_DELEGATOR(evaluateSymbol, pos, phase);
   }
 
   Probability evaluateSequence(unsigned int begin,
                                unsigned int end,
                                unsigned int phase) const override {
-    const_cast<Self *>(this)->lazyInitializeCache(phase);
+    const_cast<Self*>(this)->lazyInitializeCache(phase);
     CALL_MEMBER_FUNCTION_DELEGATOR(evaluateSequence, begin, end, phase);
   }
 

--- a/include/model/CachedLabeler.hpp
+++ b/include/model/CachedLabeler.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <type_traits>
 
-// ToPS headers
+// Internal headers
 #include "model/Labeling.hpp"
 #include "model/Sequence.hpp"
 #include "model/Estimation.hpp"

--- a/include/model/CachedTrainer.hpp
+++ b/include/model/CachedTrainer.hpp
@@ -24,7 +24,7 @@
 #include <tuple>
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/Trainer.hpp"
 
 namespace tops {

--- a/include/model/Calculator.hpp
+++ b/include/model/Calculator.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/Symbol.hpp"
 #include "model/Sequence.hpp"
 #include "model/Probability.hpp"

--- a/include/model/Consensus.hpp
+++ b/include/model/Consensus.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "Sequence.hpp"
 
 namespace tops {

--- a/include/model/ContextTree.hpp
+++ b/include/model/ContextTree.hpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Sequence.hpp"
 #include "model/ContextTreeNode.hpp"
 

--- a/include/model/ContextTree.hpp
+++ b/include/model/ContextTree.hpp
@@ -54,25 +54,25 @@ class ContextTree {
 
   // Concrete methods
   int alphabetSize() const;
-  std::vector<ContextTreeNodePtr> & all_context();
+  std::vector<ContextTreeNodePtr>& all_context();
   ContextTreeNodePtr getRoot() const;
   ContextTreeNodePtr createContext();
   ContextTreeNodePtr getContext(int id);
-  ContextTreeNodePtr getContext(const Sequence & s, int i);
+  ContextTreeNodePtr getContext(const Sequence& s, int i);
   std::set<int> getLevelOneNodes();
   void removeContextNotUsed();
   void normalize();
   void normalize(ProbabilisticModelPtr old, double pseudocount);
-  void initializeCounter(const std::vector<Sequence> &sequences,
+  void initializeCounter(const std::vector<Sequence>& sequences,
                          int order,
-                         const std::vector<double> &weights);
-  void initializeCounter(const std::vector<Sequence> &sequences,
+                         const std::vector<double>& weights);
+  void initializeCounter(const std::vector<Sequence>& sequences,
                          int order,
                          double pseudocounts,
-                         const std::vector<double> &weights);
+                         const std::vector<double>& weights);
   void pruneTree(double delta);
   void pruneTreeSmallSampleSize(int small_);
-  void initializeContextTreeRissanen(const std::vector<Sequence> &sequences);
+  void initializeContextTreeRissanen(const std::vector<Sequence>& sequences);
   int getNumberOfNodes() const;
 
  private:

--- a/include/model/ContextTreeNode.hpp
+++ b/include/model/ContextTreeNode.hpp
@@ -25,7 +25,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/DiscreteIIDModel.hpp"
 
 namespace tops {

--- a/include/model/DecodableModel.hpp
+++ b/include/model/DecodableModel.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Labeler.hpp"
 #include "model/Labeling.hpp"
 #include "model/Calculator.hpp"

--- a/include/model/DecodableModel.hpp
+++ b/include/model/DecodableModel.hpp
@@ -50,16 +50,16 @@ class DecodableModel : public virtual ProbabilisticModel {
  public:
   // Purely virtual methods
   virtual EvaluatorPtr<Labeling> labelingEvaluator(
-      const Labeling<Sequence> &sequence, bool cached = false) = 0;
+      const Labeling<Sequence>& sequence, bool cached = false) = 0;
 
   virtual GeneratorPtr<Labeling> labelingGenerator(
       RandomNumberGeneratorPtr rng = RNGAdapter<std::mt19937>::make()) = 0;
 
   virtual LabelerPtr labeler(
-      const Sequence &sequence, bool cached = false) = 0;
+      const Sequence& sequence, bool cached = false) = 0;
 
   virtual CalculatorPtr calculator(
-      const Sequence &sequence, bool cached = false) = 0;
+      const Sequence& sequence, bool cached = false) = 0;
 
   // Destructor
   virtual ~DecodableModel() = default;

--- a/include/model/DecodableModelCrtp.hpp
+++ b/include/model/DecodableModelCrtp.hpp
@@ -110,16 +110,16 @@ class DecodableModelCrtp
 
   // Overriden methods
   EvaluatorPtr<Labeling>
-  labelingEvaluator(const Labeling<Sequence> &sequence,
+  labelingEvaluator(const Labeling<Sequence>& sequence,
                     bool cached = false) override;
 
   GeneratorPtr<Labeling>
   labelingGenerator(RandomNumberGeneratorPtr rng
                       = RNGAdapter<std::mt19937>::make()) override;
 
-  LabelerPtr labeler(const Sequence &sequence, bool cached = false) override;
+  LabelerPtr labeler(const Sequence& sequence, bool cached = false) override;
 
-  CalculatorPtr calculator(const Sequence &sequence,
+  CalculatorPtr calculator(const Sequence& sequence,
                            bool cached = false) override;
 
   // Purely virtual methods
@@ -145,7 +145,7 @@ class DecodableModelCrtp
   virtual Labeling<Symbol> drawSymbol(SGPtr<Labeling> generator,
                                       unsigned int pos,
                                       unsigned int phase,
-                                      const Sequence &context) const = 0;
+                                      const Sequence& context) const = 0;
   virtual Labeling<Sequence> drawSequence(SGPtr<Labeling> generator,
                                           unsigned int size,
                                           unsigned int phase) const = 0;
@@ -153,21 +153,21 @@ class DecodableModelCrtp
   virtual void initializeCache(CLPtr labeler) = 0;
 
   virtual Estimation<Labeling<Sequence>>
-  labeling(SLPtr labeler, const Labeler::method &method) const = 0;
+  labeling(SLPtr labeler, const Labeler::method& method) const = 0;
 
   virtual Estimation<Labeling<Sequence>>
-  labeling(CLPtr labeler, const Labeler::method &method) const = 0;
+  labeling(CLPtr labeler, const Labeler::method& method) const = 0;
 
   virtual void initializeCache(CCPtr calculator) = 0;
 
   virtual Probability
-  calculate(SCPtr calculator, const Calculator::direction &direction) const = 0;
+  calculate(SCPtr calculator, const Calculator::direction& direction) const = 0;
 
   virtual Probability
-  calculate(CCPtr calculator, const Calculator::direction &direction) const = 0;
+  calculate(CCPtr calculator, const Calculator::direction& direction) const = 0;
 
-  virtual void posteriorProbabilities(const Sequence &xs,
-                                      Matrix &probabilities) const = 0;
+  virtual void posteriorProbabilities(const Sequence& xs,
+                                      Matrix& probabilities) const = 0;
 
   // Virtual methods
   unsigned int stateAlphabetSize() const;

--- a/include/model/DecodableModelCrtp.hpp
+++ b/include/model/DecodableModelCrtp.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/State.hpp"
 #include "model/Labeler.hpp"
 #include "model/Calculator.hpp"

--- a/include/model/DiscreteIIDModel.hpp
+++ b/include/model/DiscreteIIDModel.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/ProbabilisticModelCrtp.hpp"
 
 namespace tops {

--- a/include/model/DiscreteIIDModel.hpp
+++ b/include/model/DiscreteIIDModel.hpp
@@ -185,7 +185,7 @@ class DiscreteIIDModel : public ProbabilisticModelCrtp<DiscreteIIDModel> {
   Standard<Symbol> drawSymbol(SGPtr<Standard> generator,
                               unsigned int pos,
                               unsigned int phase,
-                              const Sequence &context) const override;
+                              const Sequence& context) const override;
 
   // Virtual methods
 
@@ -220,29 +220,29 @@ class DiscreteIIDModel : public ProbabilisticModelCrtp<DiscreteIIDModel> {
   static double epanechnikov(double x, double h);
   static void band_den_bin(int n,
                            int nb,
-                           double *d,
-                           const std::vector<double> &x,
-                           std::vector<double> &cnt);
+                           double* d,
+                           const std::vector<double>& x,
+                           std::vector<double>& cnt);
   static void band_phi6_bin(int n,
                             int nb,
                             double d,
-                            std::vector<double> &x,
+                            std::vector<double>& x,
                             double h,
-                            double *u);
+                            double* u);
   static void band_phi4_bin(int n,
                             int nb,
                             double d,
                             std::vector<double> x,
                             double h,
-                            double *u);
-  static double mean(const std::vector<double> &data);
-  static double var(const std::vector<double> &data);
+                            double* u);
+  static double mean(const std::vector<double>& data);
+  static double var(const std::vector<double>& data);
   static double quantile(std::vector<double> data, double q);
-  static double iqr(const std::vector<double> &data);
+  static double iqr(const std::vector<double>& data);
   static double kernel_density_estimation(double x,
                                           double bw,
-                                          const std::vector<double> &data);
-  static double sj_bandwidth(const std::vector<double> &data);
+                                          const std::vector<double>& data);
+  static double sj_bandwidth(const std::vector<double>& data);
 };
 
 }  // namespace model

--- a/include/model/Duration.hpp
+++ b/include/model/Duration.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/Range.hpp"
 #include "model/Serializer.hpp"
 #include "model/Probability.hpp"

--- a/include/model/DurationCrtp.hpp
+++ b/include/model/DurationCrtp.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/Duration.hpp"
 #include "model/SimpleSerializer.hpp"
 

--- a/include/model/DurationState.hpp
+++ b/include/model/DurationState.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Duration.hpp"
 #include "model/StateCrtp.hpp"
 

--- a/include/model/Evaluator.hpp
+++ b/include/model/Evaluator.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "Probability.hpp"
 
 namespace tops {

--- a/include/model/ExplicitDuration.hpp
+++ b/include/model/ExplicitDuration.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/DurationCrtp.hpp"
 #include "model/ProbabilisticModel.hpp"
 

--- a/include/model/FixedSequenceAtPosition.hpp
+++ b/include/model/FixedSequenceAtPosition.hpp
@@ -72,7 +72,7 @@ class FixedSequenceAtPosition
   DiscreteIIDModelPtr _probabilities;
 
   // Concrete methods
-  void addSequence(Sequence &h) const;
+  void addSequence(Sequence& h) const;
 };
 
 }  // namespace model

--- a/include/model/FixedSequenceAtPosition.hpp
+++ b/include/model/FixedSequenceAtPosition.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/DiscreteIIDModel.hpp"
 #include "model/ProbabilisticModelDecoratorCrtp.hpp"
 

--- a/include/model/FixedTrainer.hpp
+++ b/include/model/FixedTrainer.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/Trainer.hpp"
 
 namespace tops {

--- a/include/model/FixedTrainer.hpp
+++ b/include/model/FixedTrainer.hpp
@@ -66,7 +66,7 @@ class FixedTrainer
   // Overriden methods
   TrainingSet& training_set() override {
     return const_cast<TrainingSet&>(
-      static_cast<const Self *>(this)->training_set());
+      static_cast<const Self*>(this)->training_set());
   }
 
   const TrainingSet& training_set() const override {

--- a/include/model/GeneralizedHiddenMarkovModel.hpp
+++ b/include/model/GeneralizedHiddenMarkovModel.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Matrix.hpp"
 #include "model/DurationState.hpp"
 #include "model/DecodableModelCrtp.hpp"

--- a/include/model/GeneralizedHiddenMarkovModel.hpp
+++ b/include/model/GeneralizedHiddenMarkovModel.hpp
@@ -115,12 +115,12 @@ class GeneralizedHiddenMarkovModel
   Standard<Symbol> drawSymbol(SGPtr<Standard> generator,
                               unsigned int pos,
                               unsigned int phase,
-                              const Sequence &context) const override;
+                              const Sequence& context) const override;
 
   Labeling<Symbol> drawSymbol(SGPtr<Labeling> generator,
                               unsigned int pos,
                               unsigned int phase,
-                              const Sequence &context) const override;
+                              const Sequence& context) const override;
   Labeling<Sequence> drawSequence(SGPtr<Labeling> generator,
                                   unsigned int size,
                                   unsigned int phase) const override;
@@ -128,22 +128,22 @@ class GeneralizedHiddenMarkovModel
   void initializeCache(CLPtr labeler) override;
   Estimation<Labeling<Sequence>> labeling(
       CLPtr labeler,
-      const Labeler::method &method) const override;
+      const Labeler::method& method) const override;
 
   Estimation<Labeling<Sequence>> labeling(
       SLPtr labeler,
-      const Labeler::method &method) const override;
+      const Labeler::method& method) const override;
 
   void initializeCache(CCPtr calculator) override;
 
   Probability calculate(
-      SCPtr calculator, const Calculator::direction &direction) const override;
+      SCPtr calculator, const Calculator::direction& direction) const override;
 
   Probability calculate(
-      CCPtr calculator, const Calculator::direction &direction) const override;
+      CCPtr calculator, const Calculator::direction& direction) const override;
 
-  void posteriorProbabilities(const Sequence &sequence,
-                              Matrix &probabilities) const override;
+  void posteriorProbabilities(const Sequence& sequence,
+                              Matrix& probabilities) const override;
 
  protected:
   // Instance variables
@@ -152,25 +152,25 @@ class GeneralizedHiddenMarkovModel
  private:
   // Concrete methods
   Estimation<Labeling<Sequence>> viterbi(
-      const Sequence &xs,
-      Matrix &gamma,
-      std::vector<EvaluatorPtr<Standard>> &observation_evaluators) const;
+      const Sequence& xs,
+      Matrix& gamma,
+      std::vector<EvaluatorPtr<Standard>>& observation_evaluators) const;
 
   Estimation<Labeling<Sequence>>
-  posteriorDecoding(const Sequence &xs, Matrix &probabilities) const;
+  posteriorDecoding(const Sequence& xs, Matrix& probabilities) const;
 
   Probability forward(
-      const Sequence &sequence,
-      Matrix &alpha,
-      std::vector<EvaluatorPtr<Standard>> &observation_evaluators) const;
+      const Sequence& sequence,
+      Matrix& alpha,
+      std::vector<EvaluatorPtr<Standard>>& observation_evaluators) const;
 
   Probability backward(
-      const Sequence &sequence,
-      Matrix &beta,
-      std::vector<EvaluatorPtr<Standard>> &observation_evaluators) const;
+      const Sequence& sequence,
+      Matrix& beta,
+      std::vector<EvaluatorPtr<Standard>>& observation_evaluators) const;
 
   std::vector<EvaluatorPtr<Standard>> initializeObservationEvaluators(
-      const Sequence &xs, bool cached) const;
+      const Sequence& xs, bool cached) const;
 };
 
 }  // namespace model

--- a/include/model/Generator.hpp
+++ b/include/model/Generator.hpp
@@ -53,7 +53,7 @@ class Generator : public std::enable_shared_from_this<Generator<Decorator>> {
   // Purely virtual methods
   virtual Decorator<Symbol> drawSymbol(unsigned int pos,
                                        unsigned int phase = 0,
-                                       const Sequence &context = {}) const = 0;
+                                       const Sequence& context = {}) const = 0;
 
   virtual Decorator<Sequence> drawSequence(unsigned int size,
                                            unsigned int phase = 0) const = 0;

--- a/include/model/Generator.hpp
+++ b/include/model/Generator.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <exception>
 
-// ToPS headers
+// Internal headers
 #include "Symbol.hpp"
 #include "Sequence.hpp"
 #include "RandomNumberGenerator.hpp"

--- a/include/model/GeometricDuration.hpp
+++ b/include/model/GeometricDuration.hpp
@@ -24,7 +24,7 @@
 #include <cmath>
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/DurationCrtp.hpp"
 #include "model/ProbabilisticModel.hpp"
 

--- a/include/model/HiddenMarkovModel.hpp
+++ b/include/model/HiddenMarkovModel.hpp
@@ -130,12 +130,12 @@ class HiddenMarkovModel
   Standard<Symbol> drawSymbol(SGPtr<Standard> generator,
                               unsigned int pos,
                               unsigned int phase,
-                              const Sequence &context) const override;
+                              const Sequence& context) const override;
 
   Labeling<Symbol> drawSymbol(SGPtr<Labeling> generator,
                               unsigned int pos,
                               unsigned int phase,
-                              const Sequence &context) const override;
+                              const Sequence& context) const override;
   Labeling<Sequence> drawSequence(SGPtr<Labeling> generator,
                                   unsigned int size,
                                   unsigned int phase) const override;
@@ -143,40 +143,40 @@ class HiddenMarkovModel
   void initializeCache(CLPtr labeler) override;
   Estimation<Labeling<Sequence>> labeling(
       CLPtr labeler,
-      const Labeler::method &method) const override;
+      const Labeler::method& method) const override;
 
   Estimation<Labeling<Sequence>> labeling(
       SLPtr labeler,
-      const Labeler::method &method) const override;
+      const Labeler::method& method) const override;
 
   void initializeCache(CCPtr calculator) override;
 
   Probability calculate(
-      SCPtr calculator, const Calculator::direction &direction) const override;
+      SCPtr calculator, const Calculator::direction& direction) const override;
 
   Probability calculate(
-      CCPtr calculator, const Calculator::direction &direction) const override;
+      CCPtr calculator, const Calculator::direction& direction) const override;
 
-  void posteriorProbabilities(const Sequence &sequence,
-                              Matrix &probabilities) const override;
+  void posteriorProbabilities(const Sequence& sequence,
+                              Matrix& probabilities) const override;
 
  private:
   // Concrete methods
   Estimation<Labeling<Sequence>>
-  viterbi(const Sequence &xs, Matrix &gamma) const;
+  viterbi(const Sequence& xs, Matrix& gamma) const;
 
   Estimation<Labeling<Sequence>>
-  posteriorDecoding(const Sequence &xs, Matrix &probabilities) const;
+  posteriorDecoding(const Sequence& xs, Matrix& probabilities) const;
 
-  void initializeStandardPrefixSumArray(const Sequence &sequence,
-                                        Cache &cache);
+  void initializeStandardPrefixSumArray(const Sequence& sequence,
+                                        Cache& cache);
   void initializeLabelingPrefixSumArray(CEPtr<Labeling> evaluator,
                                         unsigned int phase);
 
-  Probability backward(const Sequence &sequence,
-                       Matrix &beta) const;
-  Probability forward(const Sequence &sequence,
-                      Matrix &alpha) const;
+  Probability backward(const Sequence& sequence,
+                       Matrix& beta) const;
+  Probability forward(const Sequence& sequence,
+                      Matrix& alpha) const;
 };
 
 }  // namespace model

--- a/include/model/HiddenMarkovModel.hpp
+++ b/include/model/HiddenMarkovModel.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Matrix.hpp"
 #include "model/SimpleState.hpp"
 #include "model/DecodableModelCrtp.hpp"

--- a/include/model/InhomogeneousMarkovChain.hpp
+++ b/include/model/InhomogeneousMarkovChain.hpp
@@ -65,7 +65,7 @@ class InhomogeneousMarkovChain
   Standard<Symbol> drawSymbol(SGPtr<Standard> generator,
                               unsigned int pos,
                               unsigned int phase,
-                              const Sequence &context) const override;
+                              const Sequence& context) const override;
 
   // Virtual methods
   virtual unsigned int maximumTimeValue();

--- a/include/model/InhomogeneousMarkovChain.hpp
+++ b/include/model/InhomogeneousMarkovChain.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/ProbabilisticModel.hpp"
 #include "model/VariableLengthMarkovChain.hpp"
 

--- a/include/model/Labeler.hpp
+++ b/include/model/Labeler.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/Labeling.hpp"
 #include "model/Sequence.hpp"
 #include "model/Estimation.hpp"

--- a/include/model/LazzyRange.hpp
+++ b/include/model/LazzyRange.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "Range.hpp"
 
 namespace tops {

--- a/include/model/MaximalDependenceDecomposition.hpp
+++ b/include/model/MaximalDependenceDecomposition.hpp
@@ -92,7 +92,7 @@ class MaximalDependenceDecomposition
   Standard<Symbol> drawSymbol(SGPtr<Standard> generator,
                               unsigned int pos,
                               unsigned int phase,
-                              const Sequence &context) const override;
+                              const Sequence& context) const override;
   Standard<Sequence> drawSequence(SGPtr<Standard> generator,
                                   unsigned int size,
                                   unsigned int phase) const override;
@@ -114,7 +114,7 @@ class MaximalDependenceDecomposition
 
   static MaximalDependenceDecompositionNodePtr newNode(
       std::string node_name,
-      std::vector<Sequence> & sequences,
+      std::vector<Sequence>& sequences,
       unsigned int divmin,
       Sequence selected,
       unsigned int alphabet_size,
@@ -122,7 +122,7 @@ class MaximalDependenceDecomposition
       ProbabilisticModelPtr consensus_model);
 
   static InhomogeneousMarkovChainPtr trainInhomogeneousMarkovChain(
-      std::vector<Sequence> & sequences,
+      std::vector<Sequence>& sequences,
       unsigned int alphabet_size);
 
   static int getMaximalDependenceIndex(
@@ -133,16 +133,16 @@ class MaximalDependenceDecomposition
       ProbabilisticModelPtr consensus_model);
 
   static void subset(int index,
-                     std::vector<Sequence> & sequences,
-                     std::vector<Sequence> & consensus,
-                     std::vector<Sequence> & nonconsensus,
+                     std::vector<Sequence>& sequences,
+                     std::vector<Sequence>& consensus,
+                     std::vector<Sequence>& nonconsensus,
                      ConsensusSequence consensus_sequence);
 
   // Concrete methods
-  Probability _probabilityOf(const Sequence &s,
+  Probability _probabilityOf(const Sequence& s,
                         MaximalDependenceDecompositionNodePtr node,
-                        std::vector<int> &indexes) const;
-  void _drawAux(Sequence & s, MaximalDependenceDecompositionNodePtr node) const;
+                        std::vector<int>& indexes) const;
+  void _drawAux(Sequence& s, MaximalDependenceDecompositionNodePtr node) const;
 };
 
 }  // namespace model

--- a/include/model/MaximalDependenceDecomposition.hpp
+++ b/include/model/MaximalDependenceDecomposition.hpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Consensus.hpp"
 #include "model/InhomogeneousMarkovChain.hpp"
 #include "model/MaximalDependenceDecompositionNode.hpp"

--- a/include/model/MaximalDependenceDecompositionNode.hpp
+++ b/include/model/MaximalDependenceDecompositionNode.hpp
@@ -25,7 +25,7 @@
 #include <vector>
 #include <string>
 
-// ToPS headers
+// Internal headers
 #include "model/ProbabilisticModel.hpp"
 
 namespace tops {

--- a/include/model/MemberDelegator.hpp
+++ b/include/model/MemberDelegator.hpp
@@ -91,14 +91,14 @@ struct inject_first_parameter<Ptr, Result(Klass::*)(Args...) const> {
 
 template<typename Func, template<typename...> class Pack,
          typename Ptr, typename... Args, std::size_t... I>
-auto call_helper(const Func &func, const Ptr &ptr, const Pack<Args...> &params,
+auto call_helper(const Func& func, const Ptr& ptr, const Pack<Args...>& params,
                    std::index_sequence<I...>) {
   return func(ptr, std::get<I>(params)...);
 }
 
 template<typename Func, template<typename...> class Pack,
          typename Ptr, typename... Args>
-auto call(const Func &func, const Ptr &ptr, const Pack<Args...> &params) {
+auto call(const Func& func, const Ptr& ptr, const Pack<Args...>& params) {
   return call_helper(func, ptr, params, std::index_sequence_for<Args...>{});
 }
 
@@ -134,7 +134,7 @@ template<typename... Args>                                                     \
 inline auto method##Impl(Args&&... args)                                       \
     -> decltype(this->method(std::forward<Args>(args)...)) {                   \
   return static_cast<non_const_return_t<decltype(this->method(args...))>>(     \
-    static_cast<const class_of_t<decltype(this)> *>(this)->method##Impl(       \
+    static_cast<const class_of_t<decltype(this)>*>(this)->method##Impl(        \
       std::forward<Args>(args)...));                                           \
 }
 
@@ -171,7 +171,7 @@ inline auto method##Impl(Args&&... args)                                       \
     -> decltype(this->method(std::forward<Args>(args)...)) {                   \
   return static_cast<non_const_return_t<                                       \
             decltype(this->method(std::forward<Args>(args)...))>>(             \
-    static_cast<const class_of_t<decltype(this)> *>(this)->method##Impl(       \
+    static_cast<const class_of_t<decltype(this)>*>(this)->method##Impl(        \
       std::forward<Args>(args)...));                                           \
 }                                                                              \
                                                                                \

--- a/include/model/MemberDelegator.hpp
+++ b/include/model/MemberDelegator.hpp
@@ -20,7 +20,7 @@
 #ifndef TOPS_MODEL_MEMBER_DELEGATOR_
 #define TOPS_MODEL_MEMBER_DELEGATOR_
 
-// ToPS headers
+// Internal headers
 #include "model/MemberDetector.hpp"
 
 namespace tops {

--- a/include/model/MultipleSequentialModel.hpp
+++ b/include/model/MultipleSequentialModel.hpp
@@ -85,7 +85,7 @@ class MultipleSequentialModel
   Standard<Symbol> drawSymbol(SGPtr<Standard> generator,
                               unsigned int pos,
                               unsigned int phase,
-                              const Sequence &context) const override;
+                              const Sequence& context) const override;
 
  private:
   // Instance variables

--- a/include/model/MultipleSequentialModel.hpp
+++ b/include/model/MultipleSequentialModel.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/ProbabilisticModel.hpp"
 #include "model/ProbabilisticModelCrtp.hpp"
 

--- a/include/model/PhasedInhomogeneousMarkovChain.hpp
+++ b/include/model/PhasedInhomogeneousMarkovChain.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Matrix.hpp"
 #include "model/InhomogeneousMarkovChain.hpp"
 #include "model/VariableLengthMarkovChain.hpp"

--- a/include/model/PhasedInhomogeneousMarkovChain.hpp
+++ b/include/model/PhasedInhomogeneousMarkovChain.hpp
@@ -104,7 +104,7 @@ class PhasedInhomogeneousMarkovChain
   Standard<Symbol> drawSymbol(SGPtr<Standard> generator,
                               unsigned int pos,
                               unsigned int phase,
-                              const Sequence &context) const override;
+                              const Sequence& context) const override;
 
  private:
   // Instance variables

--- a/include/model/PhasedRunLengthDistribution.hpp
+++ b/include/model/PhasedRunLengthDistribution.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/DiscreteIIDModel.hpp"
 
 namespace tops {

--- a/include/model/ProbabilisticModel.hpp
+++ b/include/model/ProbabilisticModel.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <random>
 
-// ToPS headers
+// Internal headers
 #include "model/Sequence.hpp"
 #include "model/Standard.hpp"
 #include "model/Evaluator.hpp"

--- a/include/model/ProbabilisticModel.hpp
+++ b/include/model/ProbabilisticModel.hpp
@@ -53,7 +53,7 @@ class ProbabilisticModel {
  public:
   // Purely virtual methods
   virtual EvaluatorPtr<Standard> standardEvaluator(
-      const Standard<Sequence> &sequence, bool cached = false) = 0;
+      const Standard<Sequence>& sequence, bool cached = false) = 0;
 
   virtual GeneratorPtr<Standard> standardGenerator(
       RandomNumberGeneratorPtr rng = RNGAdapter<std::mt19937>::make()) = 0;

--- a/include/model/ProbabilisticModelCrtp.hpp
+++ b/include/model/ProbabilisticModelCrtp.hpp
@@ -93,7 +93,7 @@ class ProbabilisticModelCrtp
 
   // Overriden methods
   EvaluatorPtr<Standard>
-  standardEvaluator(const Standard<Sequence> &sequence,
+  standardEvaluator(const Standard<Sequence>& sequence,
                     bool cached = false) override;
 
   GeneratorPtr<Standard>
@@ -110,7 +110,7 @@ class ProbabilisticModelCrtp
   virtual Standard<Symbol> drawSymbol(SGPtr<Standard> generator,
                                       unsigned int pos,
                                       unsigned int phase,
-                                      const Sequence &context) const = 0;
+                                      const Sequence& context) const = 0;
 
   // Virtual methods
   virtual void initializeCache(CEPtr<Standard> evaluator,

--- a/include/model/ProbabilisticModelCrtp.hpp
+++ b/include/model/ProbabilisticModelCrtp.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Trainer.hpp"
 #include "model/Sequence.hpp"
 #include "model/FixedTrainer.hpp"

--- a/include/model/ProbabilisticModelDecoratorCrtp.hpp
+++ b/include/model/ProbabilisticModelDecoratorCrtp.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/ProbabilisticModelCrtp.hpp"
 
 namespace tops {

--- a/include/model/ProbabilisticModelDecoratorCrtp.hpp
+++ b/include/model/ProbabilisticModelDecoratorCrtp.hpp
@@ -73,7 +73,7 @@ class ProbabilisticModelDecoratorCrtp
   Standard<Symbol> drawSymbol(SGPtr<Standard> generator,
                               unsigned int pos,
                               unsigned int phase,
-                              const Sequence &context) const override;
+                              const Sequence& context) const override;
 
   Probability evaluateSymbol(SEPtr<Standard> evaluator,
                              unsigned int pos,

--- a/include/model/RandomNumberGeneratorAdapter.hpp
+++ b/include/model/RandomNumberGeneratorAdapter.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <random>
 
-// ToPS headers
+// Internal headers
 #include "model/RandomNumberGenerator.hpp"
 
 namespace tops {

--- a/include/model/Segment.hpp
+++ b/include/model/Segment.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "Symbol.hpp"
 #include "Sequence.hpp"
 

--- a/include/model/Segment.hpp
+++ b/include/model/Segment.hpp
@@ -36,7 +36,7 @@ class Segment {
   Segment(Symbol symbol, int begin, int end);
 
   // Static methods
-  static std::vector<Segment> readSequence(const Sequence &s);
+  static std::vector<Segment> readSequence(const Sequence& s);
 
   // Concrete methods
   Symbol symbol();

--- a/include/model/Sequence.hpp
+++ b/include/model/Sequence.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Symbol.hpp"
 
 namespace tops {

--- a/include/model/Serializer.hpp
+++ b/include/model/Serializer.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/Translator.hpp"
 
 namespace tops {

--- a/include/model/SignalDuration.hpp
+++ b/include/model/SignalDuration.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/DurationCrtp.hpp"
 
 namespace tops {

--- a/include/model/SimilarityBasedSequenceWeighting.hpp
+++ b/include/model/SimilarityBasedSequenceWeighting.hpp
@@ -25,7 +25,7 @@
 #include <vector>
 #include <map>
 
-// ToPS headers
+// Internal headers
 #include "model/ProbabilisticModel.hpp"
 #include "model/ProbabilisticModelCrtp.hpp"
 

--- a/include/model/SimilarityBasedSequenceWeighting.hpp
+++ b/include/model/SimilarityBasedSequenceWeighting.hpp
@@ -100,7 +100,7 @@ class SimilarityBasedSequenceWeighting
   Standard<Symbol> drawSymbol(SGPtr<Standard> generator,
                               unsigned int pos,
                               unsigned int phase,
-                              const Sequence &context) const override;
+                              const Sequence& context) const override;
 
  private:
   // Instance variables
@@ -115,7 +115,7 @@ class SimilarityBasedSequenceWeighting
   static double calculate_normalizer(int skip_length,
                                      int skip_offset,
                                      int max_length,
-                                     std::map<Sequence, double> &counter,
+                                     std::map<Sequence, double>& counter,
                                      int alphabet_size);
 };
 

--- a/include/model/SimpleCalculator.hpp
+++ b/include/model/SimpleCalculator.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/Sequence.hpp"
 #include "model/Calculator.hpp"
 

--- a/include/model/SimpleEvaluator.hpp
+++ b/include/model/SimpleEvaluator.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/Labeling.hpp"
 #include "model/Sequence.hpp"
 #include "model/Evaluator.hpp"

--- a/include/model/SimpleGenerator.hpp
+++ b/include/model/SimpleGenerator.hpp
@@ -65,7 +65,7 @@ class SimpleGenerator : public Generator<Decorator> {
   // Overriden methods
   Decorator<Symbol> drawSymbol(unsigned int pos,
                                unsigned int phase,
-                               const Sequence &context) const override {
+                               const Sequence& context) const override {
     CALL_MEMBER_FUNCTION_DELEGATOR(drawSymbol, pos, phase, context);
   }
 

--- a/include/model/SimpleGenerator.hpp
+++ b/include/model/SimpleGenerator.hpp
@@ -25,7 +25,7 @@
 #include <typeinfo>
 #include <exception>
 
-// ToPS headers
+// Internal headers
 #include "model/Generator.hpp"
 #include "model/MemberDelegator.hpp"
 

--- a/include/model/SimpleLabeler.hpp
+++ b/include/model/SimpleLabeler.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/Labeler.hpp"
 #include "model/Sequence.hpp"
 

--- a/include/model/SimpleSerializer.hpp
+++ b/include/model/SimpleSerializer.hpp
@@ -25,7 +25,7 @@
 #include <typeinfo>
 #include <exception>
 
-// ToPS headers
+// Internal headers
 #include "model/Serializer.hpp"
 #include "model/MemberDelegator.hpp"
 

--- a/include/model/SimpleState.hpp
+++ b/include/model/SimpleState.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/StateCrtp.hpp"
 
 namespace tops {

--- a/include/model/SimpleTrainer.hpp
+++ b/include/model/SimpleTrainer.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "model/Trainer.hpp"
 
 namespace tops {

--- a/include/model/SimpleTrainer.hpp
+++ b/include/model/SimpleTrainer.hpp
@@ -66,7 +66,7 @@ class SimpleTrainer
   // Overriden methods
   TrainingSet& training_set() override {
     return const_cast<TrainingSet&>(
-      static_cast<const Self *>(this)->training_set());
+      static_cast<const Self*>(this)->training_set());
   }
 
   const TrainingSet& training_set() const override {

--- a/include/model/SingleValueRange.hpp
+++ b/include/model/SingleValueRange.hpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <memory>
 
-// ToPS headers
+// Internal headers
 #include "Range.hpp"
 
 namespace tops {

--- a/include/model/State.hpp
+++ b/include/model/State.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Serializer.hpp"
 
 namespace tops {

--- a/include/model/StateCrtp.hpp
+++ b/include/model/StateCrtp.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/State.hpp"
 #include "model/SimpleSerializer.hpp"
 

--- a/include/model/TargetModel.hpp
+++ b/include/model/TargetModel.hpp
@@ -54,7 +54,7 @@ class TargetModel : public DiscreteIIDModel {
                              unsigned int phase) const override;
 
   // Concrete methods
-  DiscreteIIDModelPtr sequenceDistribution(const Sequence &s) const;
+  DiscreteIIDModelPtr sequenceDistribution(const Sequence& s) const;
 
  private:
   // Constructors

--- a/include/model/TargetModel.hpp
+++ b/include/model/TargetModel.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/DiscreteIIDModel.hpp"
 
 namespace tops {

--- a/include/model/Trainer.hpp
+++ b/include/model/Trainer.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Sequence.hpp"
 #include "model/MemberDelegator.hpp"
 

--- a/include/model/Translator.hpp
+++ b/include/model/Translator.hpp
@@ -20,7 +20,7 @@
 #ifndef TOPS_MODEL_TRANSLATOR_
 #define TOPS_MODEL_TRANSLATOR_
 
-// ToPS headers
+// Internal headers
 #include "model/MemberDelegator.hpp"
 #include "model/HiddenMarkovModelState.hpp"
 #include "model/GeneralizedHiddenMarkovModelState.hpp"

--- a/include/model/VariableLengthMarkovChain.hpp
+++ b/include/model/VariableLengthMarkovChain.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/ContextTree.hpp"
 #include "model/ProbabilisticModel.hpp"
 

--- a/include/model/VariableLengthMarkovChain.hpp
+++ b/include/model/VariableLengthMarkovChain.hpp
@@ -97,7 +97,7 @@ class VariableLengthMarkovChain
   Standard<Symbol> drawSymbol(SGPtr<Standard> generator,
                               unsigned int pos,
                               unsigned int phase,
-                              const Sequence &context) const override;
+                              const Sequence& context) const override;
 
  private:
   // Instance variables

--- a/src/helper/DiscreteIIDModel.cpp
+++ b/src/helper/DiscreteIIDModel.cpp
@@ -24,7 +24,7 @@
 #include <cmath>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "helper/Random.hpp"
 
 #include "model/Probability.hpp"

--- a/src/helper/DiscreteIIDModel.cpp
+++ b/src/helper/DiscreteIIDModel.cpp
@@ -17,6 +17,9 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "helper/DiscreteIIDModel.hpp"
+
 // Standard headers
 #include <cmath>
 #include <vector>
@@ -25,9 +28,6 @@
 #include "helper/Random.hpp"
 
 #include "model/Probability.hpp"
-
-// Interface header
-#include "helper/DiscreteIIDModel.hpp"
 
 namespace tops {
 namespace helper {

--- a/src/helper/HiddenMarkovModel.cpp
+++ b/src/helper/HiddenMarkovModel.cpp
@@ -17,6 +17,9 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "helper/HiddenMarkovModel.hpp"
+
 // Standard headers
 #include <cmath>
 #include <vector>
@@ -25,9 +28,6 @@
 #include "helper/DiscreteIIDModel.hpp"
 
 #include "model/Probability.hpp"
-
-// Interface header
-#include "helper/HiddenMarkovModel.hpp"
 
 namespace tops {
 namespace helper {

--- a/src/helper/HiddenMarkovModel.cpp
+++ b/src/helper/HiddenMarkovModel.cpp
@@ -24,7 +24,7 @@
 #include <cmath>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "helper/DiscreteIIDModel.hpp"
 
 #include "model/Probability.hpp"

--- a/src/helper/InhomogeneousMarkovChain.cpp
+++ b/src/helper/InhomogeneousMarkovChain.cpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "helper/VariableLengthMarkovChain.hpp"
 
 namespace tops {

--- a/src/helper/InhomogeneousMarkovChain.cpp
+++ b/src/helper/InhomogeneousMarkovChain.cpp
@@ -17,14 +17,14 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "helper/InhomogeneousMarkovChain.hpp"
+
 // Standard headers
 #include <vector>
 
 // ToPS headers
 #include "helper/VariableLengthMarkovChain.hpp"
-
-// Interface header
-#include "helper/InhomogeneousMarkovChain.hpp"
 
 namespace tops {
 namespace helper {

--- a/src/helper/MaximalDependenceDecomposition.cpp
+++ b/src/helper/MaximalDependenceDecomposition.cpp
@@ -17,15 +17,15 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "helper/MaximalDependenceDecomposition.hpp"
+
 // Standard headers
 #include <cmath>
 #include <vector>
 
 // ToPS headers
 #include "helper/DiscreteIIDModel.hpp"
-
-// Interface header
-#include "helper/MaximalDependenceDecomposition.hpp"
 
 namespace tops {
 namespace helper {

--- a/src/helper/MaximalDependenceDecomposition.cpp
+++ b/src/helper/MaximalDependenceDecomposition.cpp
@@ -24,7 +24,7 @@
 #include <cmath>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "helper/DiscreteIIDModel.hpp"
 
 namespace tops {

--- a/src/helper/PhasedRunLengthDistribution.cpp
+++ b/src/helper/PhasedRunLengthDistribution.cpp
@@ -24,7 +24,7 @@
 #include <cmath>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "helper/Sequence.hpp"
 
 namespace tops {

--- a/src/helper/PhasedRunLengthDistribution.cpp
+++ b/src/helper/PhasedRunLengthDistribution.cpp
@@ -17,15 +17,15 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "helper/PhasedRunLengthDistribution.hpp"
+
 // Standard headers
 #include <cmath>
 #include <vector>
 
 // ToPS headers
 #include "helper/Sequence.hpp"
-
-// Interface header
-#include "helper/PhasedRunLengthDistribution.hpp"
 
 namespace tops {
 namespace helper {

--- a/src/helper/Random.cpp
+++ b/src/helper/Random.cpp
@@ -17,11 +17,11 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "helper/Random.hpp"
+
 // Standard headers
 #include <random>
-
-// Interface header
-#include "Random.hpp"
 
 namespace tops {
 namespace helper {

--- a/src/helper/SExprTranslator.cpp
+++ b/src/helper/SExprTranslator.cpp
@@ -17,11 +17,11 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
-// Standard headers
-#include <string>
-
 // Interface header
 #include "helper/SExprTranslator.hpp"
+
+// Standard headers
+#include <string>
 
 namespace tops {
 namespace helper {

--- a/src/helper/Sequence.cpp
+++ b/src/helper/Sequence.cpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "helper/Random.hpp"
 
 namespace tops {

--- a/src/helper/Sequence.cpp
+++ b/src/helper/Sequence.cpp
@@ -17,14 +17,14 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "helper/Sequence.hpp"
+
 // Standard headers
 #include <vector>
 
 // ToPS headers
 #include "helper/Random.hpp"
-
-// Interface header
-#include "helper/Sequence.hpp"
 
 namespace tops {
 namespace helper {

--- a/src/helper/Sequence.cpp
+++ b/src/helper/Sequence.cpp
@@ -36,7 +36,7 @@ namespace helper {
 static void generateAllCombinationsOfSymbolsImpl(
     unsigned int pos,
     model::Sequence s,
-    std::vector<model::Sequence> &sequences) {
+    std::vector<model::Sequence>& sequences) {
   model::Sequence s0 = s;
   s0[pos] = 0;
 

--- a/src/helper/VariableLengthMarkovChain.cpp
+++ b/src/helper/VariableLengthMarkovChain.cpp
@@ -24,7 +24,7 @@
 #include <cmath>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "helper/Random.hpp"
 #include "helper/DiscreteIIDModel.hpp"
 

--- a/src/helper/VariableLengthMarkovChain.cpp
+++ b/src/helper/VariableLengthMarkovChain.cpp
@@ -17,6 +17,9 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "helper/VariableLengthMarkovChain.hpp"
+
 // Standard headers
 #include <cmath>
 #include <vector>
@@ -26,9 +29,6 @@
 #include "helper/DiscreteIIDModel.hpp"
 
 #include "model/Probability.hpp"
-
-// Interface header
-#include "helper/VariableLengthMarkovChain.hpp"
 
 namespace tops {
 namespace helper {

--- a/src/model/Consensus.cpp
+++ b/src/model/Consensus.cpp
@@ -17,13 +17,13 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/Consensus.hpp"
+
 // Standard headers
 #include <cmath>
 #include <vector>
 #include <algorithm>
-
-// Interface header
-#include "model/Consensus.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/ContextTree.cpp
+++ b/src/model/ContextTree.cpp
@@ -17,14 +17,14 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/ContextTree.hpp"
+
 // Standard headers
 #include <set>
 #include <cmath>
 #include <vector>
 #include <cstdlib>
-
-// Interface header
-#include "model/ContextTree.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/ContextTree.cpp
+++ b/src/model/ContextTree.cpp
@@ -49,7 +49,7 @@ ContextTreePtr ContextTree::make(int alphabet_size) {
 /*                             CONCRETE METHODS                               */
 /*----------------------------------------------------------------------------*/
 
-std::vector<ContextTreeNodePtr> & ContextTree::all_context() {
+std::vector<ContextTreeNodePtr>& ContextTree::all_context() {
   return _all_context;
 }
 
@@ -79,7 +79,7 @@ ContextTreeNodePtr ContextTree::getContext(int id) {
 /*----------------------------------------------------------------------------*/
 
 //! get the context for the sequence s[i-1], s[i-2], s[i-3]...
-ContextTreeNodePtr ContextTree::getContext(const Sequence & s, int i) {
+ContextTreeNodePtr ContextTree::getContext(const Sequence& s, int i) {
   ContextTreeNodePtr c = _all_context[0];
   ContextTreeNodePtr p;
   int j;
@@ -197,18 +197,18 @@ void ContextTree::normalize(ProbabilisticModelPtr old, double pseudocount) {
 
 /*----------------------------------------------------------------------------*/
 
-void ContextTree::initializeCounter(const std::vector<Sequence> & sequences,
+void ContextTree::initializeCounter(const std::vector<Sequence>& sequences,
                                   int order,
-                                  const std::vector<double> &weights) {
+                                  const std::vector<double>& weights) {
   initializeCounter(sequences, order, 0, weights);
 }
 
 /*----------------------------------------------------------------------------*/
 
-void ContextTree::initializeCounter(const std::vector<Sequence> & sequences,
+void ContextTree::initializeCounter(const std::vector<Sequence>& sequences,
                                     int order,
                                     double pseudocounts,
-                                    const std::vector<double> &weights) {
+                                    const std::vector<double>& weights) {
   if (order < 0)
     order = 0;
 
@@ -360,7 +360,7 @@ void ContextTree::pruneTree(double delta) {
 /*----------------------------------------------------------------------------*/
 
 void ContextTree::initializeContextTreeRissanen(
-    const std::vector<Sequence> & sequences) {
+    const std::vector<Sequence>& sequences) {
   ContextTreeNodePtr root = createContext();
   for (int i = 0; i < static_cast<int>(_alphabet_size); i++)
     root->addCount(i);

--- a/src/model/ContextTreeNode.cpp
+++ b/src/model/ContextTreeNode.cpp
@@ -17,12 +17,12 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/ContextTreeNode.hpp"
+
 // Standard headers
 #include <vector>
 #include <cstdlib>
-
-// Interface header
-#include "model/ContextTreeNode.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/DiscreteIIDModel.cpp
+++ b/src/model/DiscreteIIDModel.cpp
@@ -17,6 +17,9 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/DiscreteIIDModel.hpp"
+
 // Standard headers
 #include <map>
 #include <cmath>
@@ -24,9 +27,6 @@
 #include <string>
 #include <vector>
 #include <algorithm>
-
-// Interface header
-#include "model/DiscreteIIDModel.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/DiscreteIIDModel.cpp
+++ b/src/model/DiscreteIIDModel.cpp
@@ -284,9 +284,9 @@ double DiscreteIIDModel::epanechnikov(double x, double h) {
 
 void DiscreteIIDModel::band_den_bin(int n,
                                     int nb,
-                                    double *d,
-                                    const std::vector<double> &x,
-                                    std::vector<double> &cnt) {
+                                    double* d,
+                                    const std::vector<double>& x,
+                                    std::vector<double>& cnt) {
   int   i, j,  nn = n;
   double xmin, xmax, rang, dd;
   for (i = 0; i < nb; i++)
@@ -313,9 +313,9 @@ void DiscreteIIDModel::band_den_bin(int n,
 void DiscreteIIDModel::band_phi6_bin(int n,
                                      int nb,
                                      double d,
-                                     std::vector<double> &x,
+                                     std::vector<double>& x,
                                      double h,
-                                     double *u) {
+                                     double* u) {
   int nn = n, nbin = nb;
   double sum = 0.0;
   for (int i = 0; i < nbin; i++) {
@@ -337,7 +337,7 @@ void DiscreteIIDModel::band_phi4_bin(int n,
                                      double d,
                                      std::vector<double> x,
                                      double h,
-                                     double *u) {
+                                     double* u) {
   int nn = n, nbin = nb;
   double sum = 0.0;
   for (int i = 0; i < nbin; i++) {
@@ -353,7 +353,7 @@ void DiscreteIIDModel::band_phi4_bin(int n,
 
 /*----------------------------------------------------------------------------*/
 
-double DiscreteIIDModel::mean(const std::vector<double> &data) {
+double DiscreteIIDModel::mean(const std::vector<double>& data) {
   double sum = 0.0;
   for (unsigned int i = 0; i < data.size(); i++) {
     sum += data[i];
@@ -363,7 +363,7 @@ double DiscreteIIDModel::mean(const std::vector<double> &data) {
 
 /*----------------------------------------------------------------------------*/
 
-double DiscreteIIDModel::var(const std::vector<double> &data) {
+double DiscreteIIDModel::var(const std::vector<double>& data) {
   double data_mean = mean(data);
   double sum = 0.0;
   for (unsigned int i = 0; i < data.size(); i++) {
@@ -387,7 +387,7 @@ double DiscreteIIDModel::quantile(std::vector<double> data, double q) {
 
 /*----------------------------------------------------------------------------*/
 
-double DiscreteIIDModel::iqr(const std::vector<double> &data) {
+double DiscreteIIDModel::iqr(const std::vector<double>& data) {
   double q1 = quantile(data, 0.25);
   double q2 = quantile(data, 0.75);
   return q2 - q1;
@@ -398,7 +398,7 @@ double DiscreteIIDModel::iqr(const std::vector<double> &data) {
 double DiscreteIIDModel::kernel_density_estimation(
     double x,
     double bw,
-    const std::vector<double> &data) {
+    const std::vector<double>& data) {
   double result = 0.0;
   for (unsigned int i = 0; i < data.size(); i++) {
     double x_xi = static_cast<double>(x) - static_cast<double>(data[i]);
@@ -410,7 +410,7 @@ double DiscreteIIDModel::kernel_density_estimation(
 
 /*----------------------------------------------------------------------------*/
 
-double DiscreteIIDModel::sj_bandwidth(const std::vector<double> &data) {
+double DiscreteIIDModel::sj_bandwidth(const std::vector<double>& data) {
   double n = static_cast<double>(data.size());
   int nb = 1000;
   double d = 1.0;

--- a/src/model/ExplicitDuration.cpp
+++ b/src/model/ExplicitDuration.cpp
@@ -20,7 +20,7 @@
 // Interface header
 #include "model/ExplicitDuration.hpp"
 
-// ToPS headers
+// Internal headers
 #include "model/LazzyRange.hpp"
 
 namespace tops {

--- a/src/model/ExplicitDuration.cpp
+++ b/src/model/ExplicitDuration.cpp
@@ -17,11 +17,11 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
-// ToPS headers
-#include "model/LazzyRange.hpp"
-
 // Interface header
 #include "model/ExplicitDuration.hpp"
+
+// ToPS headers
+#include "model/LazzyRange.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/FixedSequenceAtPosition.cpp
+++ b/src/model/FixedSequenceAtPosition.cpp
@@ -17,11 +17,11 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
-// Standard headers
-#include <vector>
-
 // Interface header
 #include "model/FixedSequenceAtPosition.hpp"
+
+// Standard headers
+#include <vector>
 
 namespace tops {
 namespace model {

--- a/src/model/FixedSequenceAtPosition.cpp
+++ b/src/model/FixedSequenceAtPosition.cpp
@@ -71,7 +71,7 @@ FixedSequenceAtPosition::drawSequence(SGPtr<Standard> generator,
 
 /*================================  OTHERS  ==================================*/
 
-void FixedSequenceAtPosition::addSequence(Sequence &h) const {
+void FixedSequenceAtPosition::addSequence(Sequence& h) const {
   auto rng = _probabilities->standardGenerator()->randomNumberGenerator();
   if (_probabilities->draw(rng) == 1)
     return;

--- a/src/model/GeneralizedHiddenMarkovModel.cpp
+++ b/src/model/GeneralizedHiddenMarkovModel.cpp
@@ -17,6 +17,9 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/GeneralizedHiddenMarkovModel.hpp"
+
 // Standard headers
 #include <cmath>
 #include <limits>
@@ -26,9 +29,6 @@
 // ToPS headers
 #include "model/Util.hpp"
 #include "model/Segment.hpp"
-
-// Interface header
-#include "model/GeneralizedHiddenMarkovModel.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/GeneralizedHiddenMarkovModel.cpp
+++ b/src/model/GeneralizedHiddenMarkovModel.cpp
@@ -203,7 +203,7 @@ GeneralizedHiddenMarkovModel::initializeCache(CLPtr labeler) {
 
 Estimation<Labeling<Sequence>>
 GeneralizedHiddenMarkovModel::labeling(CLPtr labeler,
-                                       const Labeler::method &method) const {
+                                       const Labeler::method& method) const {
   switch (method) {
     case Labeler::method::bestPath:
       return viterbi(labeler->sequence(), labeler->cache().gamma,
@@ -219,7 +219,7 @@ GeneralizedHiddenMarkovModel::labeling(CLPtr labeler,
 
 Estimation<Labeling<Sequence>>
 GeneralizedHiddenMarkovModel::labeling(SLPtr labeler,
-                                       const Labeler::method &method) const {
+                                       const Labeler::method& method) const {
   Matrix probabilities;
   auto observation_evaluators
     = initializeObservationEvaluators(labeler->sequence(), false);
@@ -244,7 +244,7 @@ void GeneralizedHiddenMarkovModel::initializeCache(CCPtr calculator) {
 /*----------------------------------------------------------------------------*/
 
 Probability GeneralizedHiddenMarkovModel::calculate(
-    SCPtr calculator, const Calculator::direction &direction) const {
+    SCPtr calculator, const Calculator::direction& direction) const {
   Matrix probabilities;
   auto observation_evaluators
     = initializeObservationEvaluators(calculator->sequence(), false);
@@ -262,7 +262,7 @@ Probability GeneralizedHiddenMarkovModel::calculate(
 /*----------------------------------------------------------------------------*/
 
 Probability GeneralizedHiddenMarkovModel::calculate(
-    CCPtr calculator, const Calculator::direction &direction) const {
+    CCPtr calculator, const Calculator::direction& direction) const {
   Matrix probabilities;
 
   switch (direction) {
@@ -283,8 +283,8 @@ Probability GeneralizedHiddenMarkovModel::calculate(
 
 
 void GeneralizedHiddenMarkovModel::posteriorProbabilities(
-    const Sequence &sequence,
-    Matrix &probabilities) const {
+    const Sequence& sequence,
+    Matrix& probabilities) const {
   probabilities = std::vector<std::vector<Probability>>(
       _state_alphabet_size,
       std::vector<Probability>(sequence.size()));
@@ -308,9 +308,9 @@ void GeneralizedHiddenMarkovModel::posteriorProbabilities(
 /*----------------------------------------------------------------------------*/
 
 Estimation<Labeling<Sequence>> GeneralizedHiddenMarkovModel::viterbi(
-      const Sequence &xs,
-      Matrix &gamma,
-      std::vector<EvaluatorPtr<Standard>> &observation_evaluators) const {
+      const Sequence& xs,
+      Matrix& gamma,
+      std::vector<EvaluatorPtr<Standard>>& observation_evaluators) const {
   gamma = std::vector<std::vector<Probability>>(
       _state_alphabet_size,
       std::vector<Probability>(xs.size()));
@@ -380,8 +380,8 @@ Estimation<Labeling<Sequence>> GeneralizedHiddenMarkovModel::viterbi(
 /*----------------------------------------------------------------------------*/
 
 Estimation<Labeling<Sequence>>
-GeneralizedHiddenMarkovModel::posteriorDecoding(const Sequence &xs,
-                                                Matrix &probabilities) const {
+GeneralizedHiddenMarkovModel::posteriorDecoding(const Sequence& xs,
+                                                Matrix& probabilities) const {
   posteriorProbabilities(xs, probabilities);
 
   Sequence path(xs.size());
@@ -404,9 +404,9 @@ GeneralizedHiddenMarkovModel::posteriorDecoding(const Sequence &xs,
 /*----------------------------------------------------------------------------*/
 
 Probability GeneralizedHiddenMarkovModel::forward(
-    const Sequence &sequence,
-    Matrix &alpha,
-    std::vector<EvaluatorPtr<Standard>> &observation_evaluators) const {
+    const Sequence& sequence,
+    Matrix& alpha,
+    std::vector<EvaluatorPtr<Standard>>& observation_evaluators) const {
   alpha = std::vector<std::vector<Probability>>(
     _state_alphabet_size, std::vector<Probability>(sequence.size()));
 
@@ -447,9 +447,9 @@ Probability GeneralizedHiddenMarkovModel::forward(
 /*----------------------------------------------------------------------------*/
 
 Probability GeneralizedHiddenMarkovModel::backward(
-    const Sequence &sequence,
-    Matrix &beta,
-    std::vector<EvaluatorPtr<Standard>> &observation_evaluators) const {
+    const Sequence& sequence,
+    Matrix& beta,
+    std::vector<EvaluatorPtr<Standard>>& observation_evaluators) const {
   beta = std::vector<std::vector<Probability>>(
     _state_alphabet_size, std::vector<Probability>(sequence.size()));
 
@@ -499,7 +499,7 @@ Probability GeneralizedHiddenMarkovModel::backward(
 
 std::vector<EvaluatorPtr<Standard>>
 GeneralizedHiddenMarkovModel::initializeObservationEvaluators(
-    const Sequence &xs, bool cached) const {
+    const Sequence& xs, bool cached) const {
   std::vector<EvaluatorPtr<Standard>> observation_evaluators;
   for (auto state : _states) {
     observation_evaluators.push_back(

--- a/src/model/GeneralizedHiddenMarkovModel.cpp
+++ b/src/model/GeneralizedHiddenMarkovModel.cpp
@@ -26,7 +26,7 @@
 #include <vector>
 #include <algorithm>
 
-// ToPS headers
+// Internal headers
 #include "model/Util.hpp"
 #include "model/Segment.hpp"
 

--- a/src/model/GeometricDuration.cpp
+++ b/src/model/GeometricDuration.cpp
@@ -20,7 +20,7 @@
 // Interface header
 #include "model/GeometricDuration.hpp"
 
-// ToPS headers
+// Internal headers
 #include "model/SingleValueRange.hpp"
 
 namespace tops {

--- a/src/model/GeometricDuration.cpp
+++ b/src/model/GeometricDuration.cpp
@@ -17,11 +17,11 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
-// ToPS headers
-#include "model/SingleValueRange.hpp"
-
 // Interface header
 #include "model/GeometricDuration.hpp"
+
+// ToPS headers
+#include "model/SingleValueRange.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/HiddenMarkovModel.cpp
+++ b/src/model/HiddenMarkovModel.cpp
@@ -26,7 +26,7 @@
 #include <vector>
 #include <algorithm>
 
-// ToPS headers
+// Internal headers
 #include "model/Util.hpp"
 
 namespace tops {

--- a/src/model/HiddenMarkovModel.cpp
+++ b/src/model/HiddenMarkovModel.cpp
@@ -317,8 +317,8 @@ HiddenMarkovModel::evaluateSymbol(SEPtr<Labeling> evaluator,
                                   unsigned int pos,
                                   unsigned int /* phase */) const {
   Probability transition;
-  const Sequence &observation = evaluator->sequence().observation();
-  const Sequence &label = evaluator->sequence().label();
+  const Sequence& observation = evaluator->sequence().observation();
+  const Sequence& label = evaluator->sequence().label();
 
   if (pos == 0)
     transition = _initial_probabilities
@@ -361,7 +361,7 @@ HiddenMarkovModel::drawSymbol(SGPtr<Standard> /* generator */,
 Labeling<Symbol> HiddenMarkovModel::drawSymbol(SGPtr<Labeling> generator,
                                                unsigned int pos,
                                                unsigned int /* phase */,
-                                               const Sequence &context) const {
+                                               const Sequence& context) const {
   auto rng = generator->randomNumberGenerator();
   Symbol y = (pos == 0) ? _initial_probabilities->draw(rng)
                         : _states[context[pos-1]]->transition()->draw(rng);
@@ -388,7 +388,7 @@ Labeling<Sequence> HiddenMarkovModel::drawSequence(SGPtr<Labeling> generator,
 
 Estimation<Labeling<Sequence>>
 HiddenMarkovModel::labeling(SLPtr labeler,
-                            const Labeler::method &method) const {
+                            const Labeler::method& method) const {
   Matrix probabilities;
   switch (method) {
     case Labeler::method::bestPath:
@@ -403,7 +403,7 @@ HiddenMarkovModel::labeling(SLPtr labeler,
 
 Estimation<Labeling<Sequence>>
 HiddenMarkovModel::labeling(CLPtr labeler,
-                            const Labeler::method &method) const {
+                            const Labeler::method& method) const {
   switch (method) {
     case Labeler::method::bestPath:
       return viterbi(labeler->sequence(), labeler->cache().gamma);
@@ -429,7 +429,7 @@ void HiddenMarkovModel::initializeCache(CCPtr /*calculator*/) {
 /*----------------------------------------------------------------------------*/
 
 Probability HiddenMarkovModel::calculate(
-    SCPtr calculator, const Calculator::direction &direction) const {
+    SCPtr calculator, const Calculator::direction& direction) const {
   Matrix probabilities;
   switch (direction) {
     case Calculator::direction::forward:
@@ -444,7 +444,7 @@ Probability HiddenMarkovModel::calculate(
 /*----------------------------------------------------------------------------*/
 
 Probability HiddenMarkovModel::calculate(
-    CCPtr calculator, const Calculator::direction &direction) const {
+    CCPtr calculator, const Calculator::direction& direction) const {
   Matrix probabilities;
   switch (direction) {
     case Calculator::direction::forward:
@@ -458,8 +458,8 @@ Probability HiddenMarkovModel::calculate(
 
 /*=================================  OTHERS  =================================*/
 
-void HiddenMarkovModel::posteriorProbabilities(const Sequence &sequence,
-                                               Matrix &probabilities) const {
+void HiddenMarkovModel::posteriorProbabilities(const Sequence& sequence,
+                                               Matrix& probabilities) const {
   probabilities = std::vector<std::vector<Probability>>(
       _state_alphabet_size,
       std::vector<Probability>(sequence.size()));
@@ -480,7 +480,7 @@ void HiddenMarkovModel::posteriorProbabilities(const Sequence &sequence,
 /*----------------------------------------------------------------------------*/
 
 void HiddenMarkovModel::initializeStandardPrefixSumArray(
-    const Sequence &sequence, Cache &cache) {
+    const Sequence& sequence, Cache& cache) {
   cache.prefix_sum_array.resize(sequence.size()+1);
   forward(sequence, cache.alpha);
   cache.prefix_sum_array[0] = 0;
@@ -497,7 +497,7 @@ void HiddenMarkovModel::initializeStandardPrefixSumArray(
 
 void HiddenMarkovModel::initializeLabelingPrefixSumArray(
     CEPtr<Labeling> evaluator, unsigned int phase) {
-  auto &prefix_sum_array = evaluator->cache().prefix_sum_array;
+  auto& prefix_sum_array = evaluator->cache().prefix_sum_array;
   prefix_sum_array.resize(evaluator->sequence().observation().size() + 1);
 
   prefix_sum_array[0] = 0;
@@ -509,8 +509,8 @@ void HiddenMarkovModel::initializeLabelingPrefixSumArray(
 /*----------------------------------------------------------------------------*/
 
 Estimation<Labeling<Sequence>>
-HiddenMarkovModel::viterbi(const Sequence &xs,
-                           Matrix &gamma) const {
+HiddenMarkovModel::viterbi(const Sequence& xs,
+                           Matrix& gamma) const {
   gamma = std::vector<std::vector<Probability>>(
       _state_alphabet_size,
       std::vector<Probability>(xs.size()));
@@ -557,8 +557,8 @@ HiddenMarkovModel::viterbi(const Sequence &xs,
 /*----------------------------------------------------------------------------*/
 
 Estimation<Labeling<Sequence>>
-HiddenMarkovModel::posteriorDecoding(const Sequence &xs,
-                                     Matrix &probabilities) const {
+HiddenMarkovModel::posteriorDecoding(const Sequence& xs,
+                                     Matrix& probabilities) const {
   posteriorProbabilities(xs, probabilities);
   Sequence path(xs.size());
 
@@ -583,8 +583,8 @@ HiddenMarkovModel::posteriorDecoding(const Sequence &xs,
 
 /*----------------------------------------------------------------------------*/
 
-Probability HiddenMarkovModel::forward(const Sequence &sequence,
-                                  Matrix &alpha) const {
+Probability HiddenMarkovModel::forward(const Sequence& sequence,
+                                  Matrix& alpha) const {
   alpha = std::vector<std::vector<Probability>>(
       _state_alphabet_size,
       std::vector<Probability>(sequence.size()));
@@ -614,8 +614,8 @@ Probability HiddenMarkovModel::forward(const Sequence &sequence,
 
 /*----------------------------------------------------------------------------*/
 
-Probability HiddenMarkovModel::backward(const Sequence &sequence,
-                                   Matrix &beta) const {
+Probability HiddenMarkovModel::backward(const Sequence& sequence,
+                                   Matrix& beta) const {
   beta = std::vector<std::vector<Probability>>(
       _state_alphabet_size,
       std::vector<Probability>(sequence.size()));

--- a/src/model/HiddenMarkovModel.cpp
+++ b/src/model/HiddenMarkovModel.cpp
@@ -17,6 +17,9 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/HiddenMarkovModel.hpp"
+
 // Standard headers
 #include <cmath>
 #include <limits>
@@ -25,9 +28,6 @@
 
 // ToPS headers
 #include "model/Util.hpp"
-
-// Interface header
-#include "model/HiddenMarkovModel.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/InhomogeneousMarkovChain.cpp
+++ b/src/model/InhomogeneousMarkovChain.cpp
@@ -17,13 +17,13 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/InhomogeneousMarkovChain.hpp"
+
 // Standard headers
 #include <cmath>
 #include <limits>
 #include <vector>
-
-// Interface header
-#include "model/InhomogeneousMarkovChain.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/InhomogeneousMarkovChain.cpp
+++ b/src/model/InhomogeneousMarkovChain.cpp
@@ -58,7 +58,7 @@ Standard<Symbol>
 InhomogeneousMarkovChain::drawSymbol(SGPtr<Standard> generator,
                                      unsigned int pos,
                                      unsigned int phase,
-                                     const Sequence &context) const {
+                                     const Sequence& context) const {
   if (pos + phase < _vlmcs.size()) {
     auto vlmc = _vlmcs[pos + phase];
     return vlmc->standardGenerator(generator->randomNumberGenerator())

--- a/src/model/MaximalDependenceDecomposition.cpp
+++ b/src/model/MaximalDependenceDecomposition.cpp
@@ -17,6 +17,9 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "MaximalDependenceDecomposition.hpp"
+
 // Standard headers
 #include <cmath>
 #include <limits>
@@ -27,9 +30,6 @@
 
 // ToPS headers
 #include "Util.hpp"
-
-// Interface header
-#include "MaximalDependenceDecomposition.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/MaximalDependenceDecomposition.cpp
+++ b/src/model/MaximalDependenceDecomposition.cpp
@@ -28,7 +28,7 @@
 #include <sstream>
 #include <algorithm>
 
-// ToPS headers
+// Internal headers
 #include "Util.hpp"
 
 namespace tops {

--- a/src/model/MaximalDependenceDecomposition.cpp
+++ b/src/model/MaximalDependenceDecomposition.cpp
@@ -92,7 +92,7 @@ MaximalDependenceDecompositionNodePtr MaximalDependenceDecomposition::trainTree(
 
 MaximalDependenceDecompositionNodePtr MaximalDependenceDecomposition::newNode(
     std::string node_name,
-    std::vector<Sequence> & sequences,
+    std::vector<Sequence>& sequences,
     unsigned int divmin,
     Sequence selected,
     unsigned int alphabet_size,
@@ -180,7 +180,7 @@ MaximalDependenceDecompositionNodePtr MaximalDependenceDecomposition::newNode(
 
 InhomogeneousMarkovChainPtr
 MaximalDependenceDecomposition::trainInhomogeneousMarkovChain(
-    std::vector<Sequence> & sequences,
+    std::vector<Sequence>& sequences,
     unsigned int alphabet_size) {
   std::vector<VariableLengthMarkovChainPtr> position_specific_vlmcs;
 
@@ -251,9 +251,9 @@ int MaximalDependenceDecomposition::getMaximalDependenceIndex(
 
 void MaximalDependenceDecomposition::subset(
     int index,
-    std::vector<Sequence> & sequences,
-    std::vector<Sequence> & consensus,
-    std::vector<Sequence> & nonconsensus,
+    std::vector<Sequence>& sequences,
+    std::vector<Sequence>& consensus,
+    std::vector<Sequence>& nonconsensus,
     ConsensusSequence consensus_sequence) {
   for (unsigned int i = 0; i < sequences.size(); i++) {
     if (consensus_sequence[index].is(sequences[i][index])) {
@@ -277,7 +277,7 @@ void MaximalDependenceDecomposition::initializeCache(CEPtr<Standard> evaluator,
 
   if (slen - clen + 1 <= 0) return;
 
-  auto &prefix_sum_array = evaluator->cache().prefix_sum_array;
+  auto& prefix_sum_array = evaluator->cache().prefix_sum_array;
   prefix_sum_array.resize(slen - clen + 1);
 
   auto simple_evaluator = static_cast<SEPtr<Standard>>(evaluator);
@@ -320,7 +320,7 @@ Probability MaximalDependenceDecomposition::evaluateSequence(
     unsigned int begin,
     unsigned int end,
     unsigned int /* phase */) const {
-  auto &prefix_sum_array = evaluator->cache().prefix_sum_array;
+  auto& prefix_sum_array = evaluator->cache().prefix_sum_array;
   if ((end - begin) != _consensus_sequence.size())
     return -std::numeric_limits<double>::infinity();
   return prefix_sum_array[begin];
@@ -353,9 +353,9 @@ Standard<Sequence> MaximalDependenceDecomposition::drawSequence(
 /*================================  OTHERS  ==================================*/
 
 Probability MaximalDependenceDecomposition::_probabilityOf(
-    const Sequence & s,
+    const Sequence& s,
     MaximalDependenceDecompositionNodePtr node,
-    std::vector<int> &indexes) const {
+    std::vector<int>& indexes) const {
   Probability p = 0;
   if (node->getLeft()) {
     p = node->getModel()
@@ -379,7 +379,7 @@ Probability MaximalDependenceDecomposition::_probabilityOf(
 /*----------------------------------------------------------------------------*/
 
 void MaximalDependenceDecomposition::_drawAux(
-    Sequence &s,
+    Sequence& s,
     MaximalDependenceDecompositionNodePtr node) const {
   if (node->getLeft()) {
     s[node->getIndex()]

--- a/src/model/MaximalDependenceDecompositionNode.cpp
+++ b/src/model/MaximalDependenceDecompositionNode.cpp
@@ -17,13 +17,13 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "MaximalDependenceDecompositionNode.hpp"
+
 // Standard headers
 #include <cmath>
 #include <string>
 #include <vector>
-
-// Interface header
-#include "MaximalDependenceDecompositionNode.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/MultipleSequentialModel.cpp
+++ b/src/model/MultipleSequentialModel.cpp
@@ -148,7 +148,7 @@ MultipleSequentialModel::evaluateSequence(CEPtr<Standard> evaluator,
                                           unsigned int begin,
                                           unsigned int end,
                                           unsigned int phase) const {
-  auto &evaluators = evaluator->cache().evaluators;
+  auto& evaluators = evaluator->cache().evaluators;
   double sum = 0;
   int b = begin;
   int e = 0;
@@ -193,7 +193,7 @@ Standard<Symbol>
 MultipleSequentialModel::drawSymbol(SGPtr<Standard> generator,
                                     unsigned int pos,
                                     unsigned int phase,
-                                    const Sequence &context) const {
+                                    const Sequence& context) const {
   int index = pos;
   for (unsigned int j = 0; j < _models.size(); j++) {
     index -= _max_length[j];

--- a/src/model/MultipleSequentialModel.cpp
+++ b/src/model/MultipleSequentialModel.cpp
@@ -17,6 +17,9 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "MultipleSequentialModel.hpp"
+
 // Standard headers
 #include <cmath>
 #include <limits>
@@ -25,9 +28,6 @@
 
 // ToPS headers
 #include "Util.hpp"
-
-// Interface header
-#include "MultipleSequentialModel.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/MultipleSequentialModel.cpp
+++ b/src/model/MultipleSequentialModel.cpp
@@ -26,7 +26,7 @@
 #include <vector>
 #include <cstdlib>
 
-// ToPS headers
+// Internal headers
 #include "Util.hpp"
 
 namespace tops {

--- a/src/model/PhasedInhomogeneousMarkovChain.cpp
+++ b/src/model/PhasedInhomogeneousMarkovChain.cpp
@@ -116,7 +116,7 @@ PhasedInhomogeneousMarkovChainPtr PhasedInhomogeneousMarkovChain::make(
 
 void PhasedInhomogeneousMarkovChain::initializeCache(CEPtr<Standard> evaluator,
                                                      unsigned int /* phase */) {
-  auto &prefix_sum_matrix = evaluator->cache().prefix_sum_matrix;
+  auto& prefix_sum_matrix = evaluator->cache().prefix_sum_matrix;
 
   prefix_sum_matrix.resize(_vlmcs.size());
   for (auto& prefix_sum_array : prefix_sum_matrix)
@@ -163,7 +163,7 @@ PhasedInhomogeneousMarkovChain::evaluateSequence(CEPtr<Standard> evaluator,
                                                  unsigned int begin,
                                                  unsigned int end,
                                                  unsigned int phase) const {
-  auto &prefix_sum_matrix = evaluator->cache().prefix_sum_matrix;
+  auto& prefix_sum_matrix = evaluator->cache().prefix_sum_matrix;
   return prefix_sum_matrix[phase][end] - prefix_sum_matrix[phase][begin];
 }
 
@@ -173,7 +173,7 @@ Standard<Symbol>
 PhasedInhomogeneousMarkovChain::drawSymbol(SGPtr<Standard> generator,
                                            unsigned int pos,
                                            unsigned int phase,
-                                           const Sequence &context) const {
+                                           const Sequence& context) const {
   auto vlmc = _vlmcs[(pos + phase) % _vlmcs.size()];
   return vlmc->standardGenerator(generator->randomNumberGenerator())
              ->drawSymbol(pos, phase, context);

--- a/src/model/PhasedInhomogeneousMarkovChain.cpp
+++ b/src/model/PhasedInhomogeneousMarkovChain.cpp
@@ -17,13 +17,13 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/PhasedInhomogeneousMarkovChain.hpp"
+
 // Standard headers
 #include <cmath>
 #include <limits>
 #include <vector>
-
-// Interface header
-#include "model/PhasedInhomogeneousMarkovChain.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/PhasedRunLengthDistribution.cpp
+++ b/src/model/PhasedRunLengthDistribution.cpp
@@ -25,7 +25,7 @@
 #include <limits>
 #include <vector>
 
-// ToPS headers
+// Internal headers
 #include "model/Util.hpp"
 
 namespace tops {

--- a/src/model/PhasedRunLengthDistribution.cpp
+++ b/src/model/PhasedRunLengthDistribution.cpp
@@ -17,6 +17,9 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/PhasedRunLengthDistribution.hpp"
+
 // Standard headers
 #include <cmath>
 #include <limits>
@@ -24,9 +27,6 @@
 
 // ToPS headers
 #include "model/Util.hpp"
-
-// Interface header
-#include "model/PhasedRunLengthDistribution.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/Segment.cpp
+++ b/src/model/Segment.cpp
@@ -38,7 +38,7 @@ Segment::Segment(Symbol symbol, int begin, int end)
 /*                               STATIC METHODS                               */
 /*----------------------------------------------------------------------------*/
 
-std::vector<Segment> Segment::readSequence(const Sequence &s) {
+std::vector<Segment> Segment::readSequence(const Sequence& s) {
   std::vector<Segment> segments;
   Symbol symbol = s[0];
   int begin = 0;

--- a/src/model/Segment.cpp
+++ b/src/model/Segment.cpp
@@ -17,11 +17,11 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
-// Standard headers
-#include <vector>
-
 // Interface header
 #include "model/Segment.hpp"
+
+// Standard headers
+#include <vector>
 
 namespace tops {
 namespace model {

--- a/src/model/SignalDuration.cpp
+++ b/src/model/SignalDuration.cpp
@@ -17,14 +17,14 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/SignalDuration.hpp"
+
 // Standard headers
 #include <limits>
 
 // ToPS headers
 #include "model/SingleValueRange.hpp"
-
-// Interface header
-#include "model/SignalDuration.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/SignalDuration.cpp
+++ b/src/model/SignalDuration.cpp
@@ -23,7 +23,7 @@
 // Standard headers
 #include <limits>
 
-// ToPS headers
+// Internal headers
 #include "model/SingleValueRange.hpp"
 
 namespace tops {

--- a/src/model/SimilarityBasedSequenceWeighting.cpp
+++ b/src/model/SimilarityBasedSequenceWeighting.cpp
@@ -17,6 +17,9 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/SimilarityBasedSequenceWeighting.hpp"
+
 // Standard headers
 #include <map>
 #include <cmath>
@@ -27,9 +30,6 @@
 
 // ToPS headers
 #include "model/Util.hpp"
-
-// Interface header
-#include "model/SimilarityBasedSequenceWeighting.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/SimilarityBasedSequenceWeighting.cpp
+++ b/src/model/SimilarityBasedSequenceWeighting.cpp
@@ -105,7 +105,7 @@ double SimilarityBasedSequenceWeighting::calculate_normalizer(
     int skip_length,
     int skip_offset,
     int max_length,
-    std::map<Sequence, double> & counter,
+    std::map<Sequence, double>& counter,
     int alphabet_size) {
   int npatterns_differ_1 = 0;
   npatterns_differ_1 = (alphabet_size - 1) * (max_length - skip_length);
@@ -145,7 +145,7 @@ double SimilarityBasedSequenceWeighting::calculate_normalizer(
 
 void SimilarityBasedSequenceWeighting::initializeCache(
     CEPtr<Standard> evaluator, unsigned int phase) {
-  auto &prefix_sum_array = evaluator->cache().prefix_sum_array;
+  auto& prefix_sum_array = evaluator->cache().prefix_sum_array;
   prefix_sum_array.resize(evaluator->sequence().size());
 
   auto sequence_size = evaluator->sequence().size();
@@ -223,7 +223,7 @@ Probability SimilarityBasedSequenceWeighting::evaluateSequence(
     unsigned int begin,
     unsigned int /* end */,
     unsigned int /* phase */) const {
-  auto &prefix_sum_array = evaluator->cache().prefix_sum_array;
+  auto& prefix_sum_array = evaluator->cache().prefix_sum_array;
   if (begin < prefix_sum_array.size())
     return prefix_sum_array[begin];
   return -std::numeric_limits<double>::infinity();

--- a/src/model/SimilarityBasedSequenceWeighting.cpp
+++ b/src/model/SimilarityBasedSequenceWeighting.cpp
@@ -28,7 +28,7 @@
 #include <vector>
 #include <sstream>
 
-// ToPS headers
+// Internal headers
 #include "model/Util.hpp"
 
 namespace tops {

--- a/src/model/TargetModel.cpp
+++ b/src/model/TargetModel.cpp
@@ -61,7 +61,7 @@ Probability TargetModel::evaluateSymbol(SEPtr<Standard> evaluator,
 /*                              CONCRETE METHODS                              */
 /*----------------------------------------------------------------------------*/
 
-DiscreteIIDModelPtr TargetModel::sequenceDistribution(const Sequence &s) const {
+DiscreteIIDModelPtr TargetModel::sequenceDistribution(const Sequence& s) const {
   auto iid_trainer = DiscreteIIDModel::standardTrainer();
   iid_trainer->add_training_sequence(s);
 

--- a/src/model/TargetModel.cpp
+++ b/src/model/TargetModel.cpp
@@ -17,12 +17,12 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/TargetModel.hpp"
+
 // Standard headers
 #include <cmath>
 #include <vector>
-
-// Interface header
-#include "model/TargetModel.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/Util.cpp
+++ b/src/model/Util.cpp
@@ -17,12 +17,12 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/Util.hpp"
+
 // Standard headers
 #include <cmath>
 #include <limits>
-
-// Interface header
-#include "model/Util.hpp"
 
 namespace tops {
 namespace model {

--- a/src/model/VariableLengthMarkovChain.cpp
+++ b/src/model/VariableLengthMarkovChain.cpp
@@ -137,7 +137,7 @@ Standard<Symbol>
 VariableLengthMarkovChain::drawSymbol(SGPtr<Standard> generator,
                                       unsigned int pos,
                                       unsigned int phase,
-                                      const Sequence &context) const {
+                                      const Sequence& context) const {
   auto c = _context_tree->getContext(context, pos);
 
   // TODO(igorbonadio): ERROR!

--- a/src/model/VariableLengthMarkovChain.cpp
+++ b/src/model/VariableLengthMarkovChain.cpp
@@ -17,13 +17,13 @@
 /*  MA 02110-1301, USA.                                                */
 /***********************************************************************/
 
+// Interface header
+#include "model/VariableLengthMarkovChain.hpp"
+
 // Standard headers
 #include <cmath>
 #include <limits>
 #include <vector>
-
-// Interface header
-#include "model/VariableLengthMarkovChain.hpp"
 
 namespace tops {
 namespace model {


### PR DESCRIPTION
@igorbonadio,

I'm preparing ToPS to bring the code from [tops-lang](https://github.com/topsframework/tops-lang) to ToPS. Some time ago, I read some style guide that says that `&` and `*` in references and pointers would be better put close to the type instead of the variable name. I did that and I fixed some other minor issues.

Issue #18 was opened for a while, although its initial objective had already been accomplished a long time ago. So I'm taking advantage of the changes described above to close it.
